### PR TITLE
Fixing random key creation during accessing List items

### DIFF
--- a/redis_collections/lists.py
+++ b/redis_collections/lists.py
@@ -119,7 +119,7 @@ class List(RedisCollection, collections.MutableSequence):
             values = map(self._unpickle, values)
 
             pipe.multi()
-            return self._create_new(values, pipe=pipe)
+            return self._create_new(values, pipe=pipe, key=self.key)
         return self._transaction(slice_trans)
 
     def __getitem__(self, index):


### PR DESCRIPTION
When List.**getitem** is called, it results in the creation of a random key.  This is because RedisCollection._create_new is called without passing the key argument.  So it defaults to the creation of a random key.
This can be fixed by passing the key of the calling List object
Fixes #23
