### PR TITLE
Dict.get() with default on key holding a false value

### DIFF
--- a/redis_collections/dicts.py
+++ b/redis_collections/dicts.py
@@ -100,7 +100,8 @@ class Dict(RedisCollection, collections.MutableMapping):
             :func:`__getitem__` protocol.
         """
         value = self.redis.hget(self.key, key)
-        if value is None: return default
+        if value is None:
+            return default
         return self._unpickle(value)
 
     def getmany(self, *keys):

--- a/redis_collections/dicts.py
+++ b/redis_collections/dicts.py
@@ -100,7 +100,8 @@ class Dict(RedisCollection, collections.MutableMapping):
             :func:`__getitem__` protocol.
         """
         value = self.redis.hget(self.key, key)
-        return self._unpickle(value) or default
+        if value is None: return default
+        return self._unpickle(value)
 
     def getmany(self, *keys):
         """Return the value for *keys*. If particular key is not in the

--- a/tests/test_dicts.py
+++ b/tests/test_dicts.py
@@ -180,6 +180,12 @@ class DictTest(RedisTestCase):
         self.assertEqual(sorted(d.items()),
                          [('a', 'g'), ('c', None), ('x', 38)])
 
+    def test_get_default(self):
+        d = self.create_dict()
+        for ff in ( '', False, None, 0):
+            d['h'] = ff
+            self.assertEqual(d.get('h', 'wrong'), ff)
+
 
 class CounterTest(RedisTestCase):
 

--- a/tests/test_dicts.py
+++ b/tests/test_dicts.py
@@ -182,7 +182,7 @@ class DictTest(RedisTestCase):
 
     def test_get_default(self):
         d = self.create_dict()
-        for ff in ( '', False, None, 0):
+        for ff in ('', False, None, 0):
             d['h'] = ff
             self.assertEqual(d.get('h', 'wrong'), ff)
 


### PR DESCRIPTION
If you store any false value, such as `None`, `''` (empty string), `0` (int zero) and so on... then get() will return the default value instead of your stored false value.

New test case to demonstrate problem, and a simple fix.