### PR TITLE
Add support for using redislite if the module is installed.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,3 @@
-include README.rst LICENSE requirements.txt
+include README.rst
+include LICENSE
+include requirements.txt

--- a/redis_collections/base.py
+++ b/redis_collections/base.py
@@ -7,7 +7,7 @@ base
 
 import uuid
 try:
-    import redislite as redis
+    import redislite
     using_redislite = True
 except ImportError:
     import redis
@@ -183,8 +183,8 @@ class RedisCollection:
 
         :rtype: :class:`redis.StrictRedis`
         """
-        if redis_dbfile and using_redislite:
-            return redis.StrictRedis(redis_dbfile)
+        if using_redislite:
+            return redislite.StrictRedis(redis_dbfile)
         return redis.StrictRedis()
 
     def _create_key(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 redis
+future

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,9 @@ setup(
     name=meta['title'],
     version=meta['version'],
     description='Set of basic Python collections backed by Redis.',
+    extras_require = {
+        'redislite':  ["redislite"]
+    },
     long_description=open('README.rst').read(),
     author=meta['author'],
     author_email='jan.javorek@gmail.com',
@@ -50,7 +53,7 @@ setup(
     license=open('LICENSE').read(),
     packages=find_packages(exclude=['tests']),
     include_package_data=True,
-    install_requires=['redis>=2.7.2'],
+    install_requires=['redis>=2.7.2', 'future'],
     zip_safe=False,
     classifiers=(
         'Development Status :: 4 - Beta',

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
     version=meta['version'],
     description='Set of basic Python collections backed by Redis.',
     extras_require = {
-        'redislite':  ["redislite"]
+        'redislite':  ["redislite==1.0.228"]
     },
     long_description=open('README.rst').read(),
     author=meta['author'],

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,14 @@ if sys.argv[-1] == 'publish':
     sys.exit()
 
 
+def readme(filename='README.rst'):
+    if sys.version_info.major > 2:
+        with open(filename, encoding='utf-8') as file_handle:
+            return file_handle.read()
+    with open(filename) as file_handle:
+        return file_handle.read()
+
+
 setup(
     name=meta['title'],
     version=meta['version'],
@@ -46,14 +54,14 @@ setup(
     extras_require = {
         'redislite':  ["redislite==1.0.228"]
     },
-    long_description=open('README.rst').read(),
+    long_description=readme(),
     author=meta['author'],
     author_email='jan.javorek@gmail.com',
     url='https://github.com/honzajavorek/redis-collections',
     license=open('LICENSE').read(),
     packages=find_packages(exclude=['tests']),
     include_package_data=True,
-    install_requires=['redis>=2.7.2', 'future'],
+    install_requires=['redis>=2.7.2'],
     zip_safe=False,
     classifiers=(
         'Development Status :: 4 - Beta',

--- a/tests/base.py
+++ b/tests/base.py
@@ -1,16 +1,23 @@
 # -*- coding: utf-8 -*-
 
 
-import redis
+try:
+    import redislite as redis
+except ImportError:
+    import redis
 import unittest
 
 
 class RedisTestCase(unittest.TestCase):
 
     db = 15
+    dbfilename = None
 
     def setUp(self):
-        self.redis = redis.StrictRedis(db=self.db)
+        if self.dbfilename and hasattr(redis, '__redis_executable__'):
+            self.redis = redis.StrictRedis(self.dbfilename, db=self.db)
+        else:
+            self.redis = redis.StrictRedis(db=self.db)
         if self.redis.dbsize():
             raise EnvironmentError('Redis database number %d is not empty, '
                                    'tests could harm your data.' % self.db)

--- a/tests/test_redislite.py
+++ b/tests/test_redislite.py
@@ -1,0 +1,27 @@
+import os
+import unittest
+from .base import RedisTestCase
+dbfilename = None
+try:
+    import redislite
+    dbfilename = 'redislite_test.rdb'
+except ImportError:
+    pass
+
+class ListTest(RedisTestCase):
+    dbfilename = dbfilename
+
+    @unittest.skipIf(not dbfilename, "The redislite module is not installed")
+    def test_redislite_pid(self):
+        """
+        The redislite server object should have a valid pid attribute
+        """
+        self.assertGreater(self.redis.pid, 0)
+
+    @unittest.skipIf(not dbfilename, "The redislite module is not installed")
+    def test_redislite_dbfile(self):
+        """
+        The db attribute on the redis object should match the dbfilename
+        :return:
+        """
+        self.assertEqual(os.path.join(os.getcwd(), self.dbfilename), self.redis.db)

--- a/tests/test_redislite.py
+++ b/tests/test_redislite.py
@@ -1,27 +1,32 @@
 import os
+import sys
 import unittest
 from .base import RedisTestCase
-dbfilename = None
-try:
-    import redislite
-    dbfilename = 'redislite_test.rdb'
-except ImportError:
-    pass
+
 
 class ListTest(RedisTestCase):
-    dbfilename = dbfilename
+    dbfilename = 'redislite.rdb'
+    @classmethod
+    def setUpClass(cls):
+        try:
+            import redislite
+        except ImportError:
+            raise unittest.SkipTest('The redislite module is not installed')
 
-    @unittest.skipIf(not dbfilename, "The redislite module is not installed")
     def test_redislite_pid(self):
         """
         The redislite server object should have a valid pid attribute
         """
         self.assertGreater(self.redis.pid, 0)
 
-    @unittest.skipIf(not dbfilename, "The redislite module is not installed")
     def test_redislite_dbfile(self):
         """
         The db attribute on the redis object should match the dbfilename
         :return:
         """
         self.assertEqual(os.path.join(os.getcwd(), self.dbfilename), self.redis.db)
+
+    @classmethod
+    def tearDownClass(cls):
+        if cls.dbfilename and os.path.exists(cls.dbfilename):
+            os.remove(cls.dbfilename)

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skip_missing_interpreters=True
-envlist = {py27,pypy}-{redis,redislite}
+envlist = {py27,py34}-{redis,redislite}
 
 [testenv]
 deps=

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,49 @@
+[tox]
+skip_missing_interpreters=True
+envlist = {py27,pypy}-{redis,redislite}
+
+[testenv]
+deps=
+    nose
+    nose-cov
+    coveralls
+    redislite: redislite
+
+commands=
+    nosetests --exe --with-xunit --xunit-file=nosetests.xml --with-coverage --cover-xml --cover-erase  --cover-package=redis_collections --cover-xml-file=cobertura.xml tests
+
+[testenv:build_docs]
+deps=
+    sphinx
+    sphinx-pypi-upload
+    sphinx_rtd_theme
+    redislite
+
+commands=
+    python setup.py build_sphinx
+
+[flake8]
+filename= *.py
+show-source = False
+
+# H104  File contains nothing but comments
+# H405  multi line docstring summary not separated with an empty line
+# H803  Commit message should not end with a period (do not remove per list discussion)
+# H904  Wrap long lines in parentheses instead of a backslash
+ignore = H104,H405,H803,H904
+
+builtins = _
+exclude=.venv,.git,.tox,build,dist,docs,*lib/python*,*egg,tools,vendor,.update-venv,*.ini,*.po,*.pot
+max-line-length = 160
+
+[testenv:pylint]
+deps=
+    pylint
+commands=
+    pylint --output-format=parseable redislite
+
+[testenv:pep8]
+deps=
+    flake8
+commands =
+    flake8 {posargs}


### PR DESCRIPTION
This adds support for using the redislite module so a separate redis server does not have to be installed.

Also added a tox.ini file to allow running unit tests on multiple python interpreters locally and getting code coverage reports.