### PR TITLE
Fixed typo. Set is now inheritable.

### DIFF
--- a/redis_collections/sets.py
+++ b/redis_collections/sets.py
@@ -249,7 +249,7 @@ class SetUnion(SetOperation):
         return s.union(*other_sets)
 
     def redisop(self, pipe, key, other_keys):
-        return pipe.suninon(key, *other_keys)
+        return pipe.sunion(key, *other_keys)
 
     def redisopstore(self, pipe, new_key, key, other_keys):
         pipe.multi()
@@ -437,7 +437,8 @@ class Set(RedisCollection, collections.MutableSet):
                 # Redis (operation) → Python → Redis (new key with List)
                 s1.difference(s2, return_cls=List)  # = List
         """
-        op = SetDifference(self, return_cls=kwargs.get('return_cls'))
+        return_cls = kwargs.get('return_cls') or type(self)
+        op = SetDifference(self, return_cls=return_cls)
         return op(*others)
 
     @same_types
@@ -519,7 +520,8 @@ class Set(RedisCollection, collections.MutableSet):
         .. note::
             The same behavior as at :func:`difference` applies.
         """
-        op = SetIntersection(self, return_cls=kwargs.get('return_cls'))
+        return_cls = kwargs.get('return_cls') or type(self)
+        op = SetIntersection(self, return_cls=return_cls)
         return op(*others)
 
     @same_types
@@ -581,7 +583,8 @@ class Set(RedisCollection, collections.MutableSet):
         .. note::
             The same behavior as at :func:`difference` applies.
         """
-        op = SetUnion(self, return_cls=kwargs.get('return_cls'))
+        return_cls = kwargs.get('return_cls') or type(self)
+        op = SetUnion(self, return_cls=return_cls)
         return op(*others)
 
     @same_types
@@ -652,7 +655,8 @@ class Set(RedisCollection, collections.MutableSet):
         .. note::
             The same behavior as at :func:`difference` applies.
         """
-        op = SetSymmetricDifference(self, return_cls=kwargs.get('return_cls'))
+        return_cls = kwargs.get('return_cls') or type(self)
+        op = SetSymmetricDifference(self, return_cls=return_cls)
         return op(other)
 
     @same_types

--- a/tests/test_sets.py
+++ b/tests/test_sets.py
@@ -216,5 +216,24 @@ class SetTest(RedisTestCase):
         self.assertEqual(sorted(s), [])
 
 
+class _Set(Set):
+    pass
+
+
+class SubClassTest(SetTest):
+    """Subclasses should be working properly, too"""
+
+    def create_set(self, *args, **kwargs):
+        kwargs['redis'] = self.redis
+        return _Set(*args, **kwargs)
+
+    def test_copy(self):
+        s1 = self.create_set('abc')
+        s2 = s1.copy()
+        self.assertEqual(s2.__class__, _Set)
+        self.assertEqual(sorted(s1),
+                         sorted(s2))
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Obviously `pipe.suninon` is a typo.

When `Set` is subclassed, the `return_cls` will still be `Set`, which makes `SetOperation.__call__` think that operations can be done completely in Redis.
For example:
```
In [1]: from redis_collections.sets import Set

In [2]: class MySet(Set):
   ...:     pass
   ...: 

In [3]: s1, s2 = Set(), Set()

In [4]: s1.add(1); s2.add(2)
Out[4]: True

In [5]: s1.union(s2)
Out[5]: <redis_collections.Set at dca9df286709428e891aa01d3a15c583 {2, 1}>

In [6]: ms1, ms2 = MySet(), MySet()

In [7]: ms1.add(1); ms2.add(2)
Out[7]: True

In [8]: ms1.union(ms2)
Out[8]: <redis_collections.Set at f5c67a9ab2e640eba602386887219c18 {'I2\n.', 'I1\n.'}>
```

Please not that `ms1.union(ms2)` outputs `{'I2\n.', 'I1\n.'}`, which should be `{2, 1}` instead.
The problem occurs because `return_cls` defaults to `Set`, not the subclass.