### PR TITLE
Version bump to 0.1.8

### DIFF
--- a/redis_collections/__init__.py
+++ b/redis_collections/__init__.py
@@ -1,7 +1,7 @@
 
 
 __title__ = 'redis-collections'
-__version__ = '0.1.7'
+__version__ = '0.1.8'
 __author__ = 'Honza Javorek'
 __license__ = 'ISC'
 __copyright__ = 'Copyright 2013-? Honza Javorek'


### PR DESCRIPTION
This PR sets the version to 0.1.8.

I missed this before tagging a few minutes ago; my mistake.