### PR TITLE
Partial Python 3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ sudo: false
 language: "python"
 python:
     - "2.7"
+    - "3.3"
+    - "3.4"
+    - "3.5"
 script: "python -m unittest discover"
 services:
     - "redis-server"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -40,8 +40,8 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'Redis Collections'
-copyright = u'2013, Honza Javorek'
+project = 'Redis Collections'
+copyright = '2013, Honza Javorek'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -196,8 +196,8 @@ latex_elements = {
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, documentclass [howto/manual]).
 latex_documents = [
-  ('index', 'RedisCollections.tex', u'Redis Collections Documentation',
-   u'Honza Javorek', 'manual'),
+  ('index', 'RedisCollections.tex', 'Redis Collections Documentation',
+   'Honza Javorek', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -226,8 +226,8 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    ('index', 'rediscollections', u'Redis Collections Documentation',
-     [u'Honza Javorek'], 1)
+    ('index', 'rediscollections', 'Redis Collections Documentation',
+     ['Honza Javorek'], 1)
 ]
 
 # If true, show URL addresses after external links.
@@ -240,8 +240,8 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-  ('index', 'RedisCollections', u'Redis Collections Documentation',
-   u'Honza Javorek', 'RedisCollections', 'One line description of project.',
+  ('index', 'RedisCollections', 'Redis Collections Documentation',
+   'Honza Javorek', 'RedisCollections', 'One line description of project.',
    'Miscellaneous'),
 ]
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -40,8 +40,8 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = 'Redis Collections'
-copyright = '2013, Honza Javorek'
+project = u'Redis Collections'
+copyright = u'2013, Honza Javorek'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -196,8 +196,8 @@ latex_elements = {
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, documentclass [howto/manual]).
 latex_documents = [
-  ('index', 'RedisCollections.tex', 'Redis Collections Documentation',
-   'Honza Javorek', 'manual'),
+  ('index', 'RedisCollections.tex', u'Redis Collections Documentation',
+   u'Honza Javorek', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -226,8 +226,8 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    ('index', 'rediscollections', 'Redis Collections Documentation',
-     ['Honza Javorek'], 1)
+    ('index', 'rediscollections', u'Redis Collections Documentation',
+     [u'Honza Javorek'], 1)
 ]
 
 # If true, show URL addresses after external links.
@@ -240,8 +240,8 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-  ('index', 'RedisCollections', 'Redis Collections Documentation',
-   'Honza Javorek', 'RedisCollections', 'One line description of project.',
+  ('index', 'RedisCollections', u'Redis Collections Documentation',
+   u'Honza Javorek', 'RedisCollections', 'One line description of project.',
    'Miscellaneous'),
 ]
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -49,9 +49,9 @@ copyright = u'2013, Honza Javorek'
 
 base_path = os.path.dirname(__file__)
 ver_file = os.path.join(base_path, '../redis_collections/__init__.py')
-ver_file_head = open(ver_file).read(100)
+ver_file_data = open(ver_file).read()
 
-match = re.search(r'__version__ = \'([^\']*)\'', ver_file_head)
+match = re.search(r'__version__ = \'([^\']*)\'', ver_file_data)
 if match:
     # The full version, including alpha/beta/rc tags.
     release = match.group(1)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -100,6 +100,17 @@ If you don't like the standard way of data serialization made by :mod:`pickle`, 
 
 New instances of collections coming from operations between them use the same ``pickler``. It is propagated as well as Redis connection.
 
+Known issues
+--------
+
+*   For ``Dict`` and its subclasses, keys are currently coerced to string types when retrieved.
+    This can lead to some incompatibilities with Python's ``dict`` - see `issue 25 <https://github.com/honzajavorek/redis-collections/issues/25>`_.
+
+*   Storing a mutable object (like a ``dict``, ``list``, or ``set``) in a ``Dict`` can lead to surprising behavior.
+    If you retrieve the object and then modify it you must explicitly store it again for changes to persist - see `issue 26 <https://github.com/honzajavorek/redis-collections/issues/25>`_.
+
+*   Support for Python 3 is in progress. Please `report <https://github.com/honzajavorek/redis-collections/issues>`_ any issues you find.
+
 Philosophy
 ----------
 

--- a/redis_collections/__init__.py
+++ b/redis_collections/__init__.py
@@ -1,4 +1,5 @@
-
+# -*- coding: utf-8 -*-
+from __future__ import division, print_function, unicode_literals
 
 __title__ = 'redis-collections'
 __version__ = '0.1.8'

--- a/redis_collections/base.py
+++ b/redis_collections/base.py
@@ -3,7 +3,7 @@
 base
 ~~~~
 """
-
+from __future__ import division, print_function, unicode_literals
 
 import uuid
 import redis

--- a/redis_collections/base.py
+++ b/redis_collections/base.py
@@ -210,7 +210,7 @@ class RedisCollection(object):
         :type data: anything serializable
         :rtype: string
         """
-        return str(self.pickler.dumps(data))
+        return self.pickler.dumps(data)
 
     def _unpickle(self, string):
         """Converts given string serialization back to corresponding data.
@@ -222,7 +222,7 @@ class RedisCollection(object):
         """
         if string is None:
             return None
-        if not isinstance(string, six.string_types):
+        if not isinstance(string, six.binary_type):
             msg = 'Only strings can be unpickled (%r given).' % string
             raise TypeError(msg)
         return self.pickler.loads(string)

--- a/redis_collections/base.py
+++ b/redis_collections/base.py
@@ -5,15 +5,16 @@ base
 """
 from __future__ import division, print_function, unicode_literals
 
+import abc
 import uuid
-import redis
-import functools
-from abc import ABCMeta, abstractmethod
-
 try:
     import cPickle as pickle
 except ImportError:
     import pickle as pickle  # NOQA
+import functools
+
+import redis
+import six
 
 
 def same_types(fn):
@@ -43,19 +44,18 @@ def same_types(fn):
     return wrapper
 
 
-class RedisCollection:
+@six.add_metaclass(abc.ABCMeta)
+class RedisCollection(object):
     """Abstract class providing backend functionality for all the other
     Redis collections.
     """
-
-    __metaclass__ = ABCMeta
 
     _same_types = ()
 
     not_impl_msg = ('Cannot be implemented efficiently or atomically '
                     'due to limitations in Redis command set.')
 
-    @abstractmethod
+    @abc.abstractmethod
     def __init__(self, data=None, redis=None, key=None, pickler=None):
         """
         :param data: Initial data.
@@ -192,7 +192,7 @@ class RedisCollection:
         """
         return uuid.uuid4().hex
 
-    @abstractmethod
+    @abc.abstractmethod
     def _data(self, pipe=None):
         """Helper for getting collection's data within a transaction.
 
@@ -222,12 +222,12 @@ class RedisCollection:
         """
         if string is None:
             return None
-        if not isinstance(string, basestring):
+        if not isinstance(string, six.string_types):
             msg = 'Only strings can be unpickled (%r given).' % string
             raise TypeError(msg)
         return self.pickler.loads(string)
 
-    @abstractmethod
+    @abc.abstractmethod
     def _update(self, data, pipe=None):
         """Helper for update operations.
 

--- a/redis_collections/dicts.py
+++ b/redis_collections/dicts.py
@@ -5,7 +5,7 @@ dicts
 
 Collections based on dict interface.
 """
-
+from __future__ import division, print_function, unicode_literals
 
 import collections
 

--- a/redis_collections/dicts.py
+++ b/redis_collections/dicts.py
@@ -83,7 +83,7 @@ class Dict(RedisCollection, collections.MutableMapping):
 
     def __iter__(self):
         """Return an iterator over the keys of the dictionary."""
-        return iter(self.redis.hkeys(self.key))
+        return (k.decode('utf-8') for k in self.redis.hkeys(self.key))
 
     def __contains__(self, key):
         """Return ``True`` if ``Dict`` instance has a key
@@ -172,7 +172,7 @@ class Dict(RedisCollection, collections.MutableMapping):
     def _data(self, pipe=None):
         redis = pipe if pipe is not None else self.redis
         result = redis.hgetall(self.key).items()
-        return [(k, self._unpickle(v)) for (k, v) in result]
+        return [(k.decode('utf-8'), self._unpickle(v)) for (k, v) in result]
 
     def items(self):
         """Return a copy of the dictionary's list of ``(key, value)`` pairs."""
@@ -181,11 +181,11 @@ class Dict(RedisCollection, collections.MutableMapping):
     def iteritems(self):
         """Return an iterator over the dictionary's ``(key, value)`` pairs."""
         result = six.iteritems(self.redis.hgetall(self.key))
-        return ((k, self._unpickle(v)) for (k, v) in result)
+        return ((k.decode('utf-8'), self._unpickle(v)) for (k, v) in result)
 
     def keys(self):
         """Return a copy of the dictionary's list of keys."""
-        return self.redis.hkeys(self.key)
+        return [k.decode('utf-8') for k in self.redis.hkeys(self.key)]
 
     def iter(self):
         """Return an iterator over the keys of the dictionary.
@@ -248,7 +248,7 @@ class Dict(RedisCollection, collections.MutableMapping):
             return key, value
 
         key, value = self._transaction(popitem_trans)
-        return key, self._unpickle(value)
+        return key.decode('utf-8'), self._unpickle(value)
 
     def setdefault(self, key, default=None):
         """If *key* is in the dictionary, return its value.
@@ -368,7 +368,7 @@ class Counter(Dict):
         super(Counter, self).__init__(*args, **kwargs)
 
     def _pickle(self, data):
-        return six.text_type(int(data))
+        return str(int(data)).encode('ascii')
 
     def _unpickle(self, string):
         if string is None:

--- a/redis_collections/lists.py
+++ b/redis_collections/lists.py
@@ -275,7 +275,7 @@ class List(RedisCollection, collections.MutableSequence):
             # Redis has no commands for *inserting* into a list by index.
             # LINSERT requires assumptions about contents of the list values.
             raise NotImplementedError(self.not_impl_msg)
-        
+
         self.redis.lpush(self.key, self._pickle(value))
 
     def append(self, value):

--- a/redis_collections/lists.py
+++ b/redis_collections/lists.py
@@ -116,7 +116,7 @@ class List(RedisCollection, collections.MutableSequence):
             if index.step:
                 # step implemented by pure Python slicing
                 values = values[::index.step]
-            values = map(self._unpickle, values)
+            values = [self._unpickle(x) for x in values]
 
             pipe.multi()
             return self._create_new(values, pipe=pipe)
@@ -287,7 +287,7 @@ class List(RedisCollection, collections.MutableSequence):
         super(List, self)._update(data, pipe)
         redis = pipe if pipe is not None else self.redis
 
-        values = map(self._pickle, data)
+        values = [self._pickle(x) for x in data]
         redis.rpush(self.key, *values)
 
     def extend(self, values):

--- a/redis_collections/lists.py
+++ b/redis_collections/lists.py
@@ -5,7 +5,7 @@ lists
 
 Collections based on list interface.
 """
-
+from __future__ import division, print_function, unicode_literals
 
 import collections
 

--- a/redis_collections/sets.py
+++ b/redis_collections/sets.py
@@ -7,17 +7,18 @@ Collections based on set interface.
 """
 from __future__ import division, print_function, unicode_literals
 
+import abc
 import itertools
 import collections
-from abc import ABCMeta, abstractmethod
+
+import six
 
 from .base import RedisCollection, same_types
 
 
+@six.add_metaclass(abc.ABCMeta)
 class SetOperation(object):
     """Helper class for implementing standard set operations."""
-
-    __metaclass__ = ABCMeta
 
     def __init__(self, s, update=False, flipped=False, return_cls=None):
         """
@@ -84,7 +85,7 @@ class SetOperation(object):
                                       pipe=pipe)
         return self.s._transaction(trans, key)
 
-    @abstractmethod
+    @abc.abstractmethod
     def op(self, s, other_sets):
         """Implementation of the operation on standard :class:`set`.
 
@@ -119,7 +120,7 @@ class SetOperation(object):
                                       pipe=pipe)
         return self.s._transaction(trans, key, *other_keys)
 
-    @abstractmethod
+    @abc.abstractmethod
     def redisop(self, pipe, key, other_keys):
         """Implementation of the operation in Redis. Results
         are returned to Python.
@@ -154,7 +155,7 @@ class SetOperation(object):
             return new
         return self.s._transaction(trans, key, *other_keys)
 
-    @abstractmethod
+    @abc.abstractmethod
     def redisopstore(self, pipe, new_key, key, other_keys):
         """Implementation of the operation in Redis. Results
         are stored to another key within Redis.
@@ -272,7 +273,7 @@ class SetSymmetricDifference(SetOperation):
     def redisop(self, pipe, key, other_keys):
         other_key = other_keys[0]  # sym. diff. supports only one operand
         elements = self._simulate_redisop(pipe, key, other_key)
-        return map(self.s._unpickle, elements)
+        return [self.s._unpickle(x) for x in elements]
 
     def redisopstore(self, pipe, new_key, key, other_keys):
         other_key = other_keys[0]  # sym. diff. supports only one operand
@@ -394,7 +395,7 @@ class Set(RedisCollection, collections.MutableSet):
             elements = [self.redis.srandmember(self.key)]
         else:
             elements = self.redis.srandmember(self.key, k)
-        return map(self._unpickle, elements)
+        return [self._unpickle(x) for x in elements]
 
     def difference(self, *others, **kwargs):
         """Return a new set with elements in the set that are
@@ -610,7 +611,9 @@ class Set(RedisCollection, collections.MutableSet):
         redis = pipe if pipe is not None else self.redis
 
         others = [data] + list(others or [])
-        elements = map(self._pickle, frozenset(itertools.chain(*others)))
+        elements = [
+            self._pickle(x) for x in frozenset(itertools.chain(*others))
+        ]
 
         redis.sadd(self.key, *elements)
 

--- a/redis_collections/sets.py
+++ b/redis_collections/sets.py
@@ -5,7 +5,7 @@ sets
 
 Collections based on set interface.
 """
-
+from __future__ import division, print_function, unicode_literals
 
 import itertools
 import collections

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 redis
+six

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,3 @@
+[flake8]
+exclude = ./docs/conf.py
+ignore = E731

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-
+from __future__ import division, print_function, unicode_literals
 
 import os
 import re

--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,8 @@ from __future__ import division, print_function, unicode_literals
 
 import os
 import re
-import sys
 import subprocess
+import sys
 
 try:
     from setuptools import setup, find_packages
@@ -48,7 +48,7 @@ setup(
     license=open('LICENSE').read(),
     packages=find_packages(exclude=['tests']),
     include_package_data=True,
-    install_requires=['redis>=2.7.2'],
+    install_requires=['redis>=2.7.2', 'six>=1.10.0'],
     zip_safe=False,
     classifiers=(
         'Development Status :: 5 - Production/Stable',

--- a/tests/base.py
+++ b/tests/base.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
+from __future__ import division, print_function, unicode_literals
 
+import unittest
 
 import redis
-import unittest
 
 
 class RedisTestCase(unittest.TestCase):

--- a/tests/test_dicts.py
+++ b/tests/test_dicts.py
@@ -29,14 +29,19 @@ class DictTest(RedisTestCase):
 
     def test_init(self):
         d = self.create_dict(zip(['one', 'two', 'three'], [1, 2, 3]))
-        self.assertEqual(sorted(d.items()),
-                         [('one', 1), ('three', 3), ('two', 2)])
+        self.assertEqual(
+            sorted(d.items()), [('one', 1), ('three', 3), ('two', 2)]
+        )
+
         d = self.create_dict([('two', 2), ('one', 1), ('three', 3)])
-        self.assertEqual(sorted(d.items()),
-                         [('one', 1), ('three', 3), ('two', 2)])
+        self.assertEqual(
+            sorted(d.items()), [('one', 1), ('three', 3), ('two', 2)]
+        )
+
         d = self.create_dict({'three': 3, 'one': 1, 'two': 2})
-        self.assertEqual(sorted(d.items()),
-                         [('one', 1), ('three', 3), ('two', 2)])
+        self.assertEqual(
+            sorted(d.items()), [('one', 1), ('three', 3), ('two', 2)]
+        )
 
     def test_key(self):
         d1 = self.create_dict()
@@ -75,11 +80,12 @@ class DictTest(RedisTestCase):
         d = self.create_dict()
         d['a'] = 'b'
         d['c'] = 'd'
-        self.assertEqual(sorted(d.items()),
-                         [('a', 'b'), ('c', 'd')])
-        self.assertEqual(sorted(d.iteritems()),
-                         [('a', 'b'), ('c', 'd')])
-        self.assertTrue(hasattr(d.iteritems(), 'next'))
+        self.assertEqual(sorted(d.items()), [('a', 'b'), ('c', 'd')])
+        self.assertEqual(sorted(d.iteritems()), [('a', 'b'), ('c', 'd')])
+        try:
+            next(d.iteritems())
+        except AttributeError:
+            self.fail()
 
     def test_copy(self):
         d1 = self.create_dict()
@@ -102,37 +108,33 @@ class DictTest(RedisTestCase):
         d = self.create_dict()
         d['a'] = 'b'
         d['c'] = 'd'
-        self.assertEqual(sorted(d.keys()),
-                         ['a', 'c'])
-        self.assertEqual(sorted(d.iterkeys()),
-                         ['a', 'c'])
-        self.assertTrue(hasattr(d.iterkeys(), 'next'))
-        self.assertEqual(sorted(d.iter()),
-                         ['a', 'c'])
-        self.assertTrue(hasattr(d.iter(), 'next'))
+        self.assertEqual(sorted(d.keys()), ['a', 'c'])
+        self.assertEqual(sorted(d.iterkeys()), ['a', 'c'])
+        self.assertEqual(sorted(d.iter()), ['a', 'c'])
+        try:
+            next(d.iter())
+        except AttributeError:
+            self.fail()
 
     def test_values(self):
         d = self.create_dict()
         d['a'] = 'b'
         d['c'] = 'd'
-        self.assertEqual(sorted(d.values()),
-                         ['b', 'd'])
-        self.assertEqual(sorted(d.itervalues()),
-                         ['b', 'd'])
-        self.assertTrue(hasattr(d.itervalues(), 'next'))
+        self.assertEqual(sorted(d.values()), ['b', 'd'])
+        self.assertEqual(sorted(d.itervalues()), ['b', 'd'])
+        try:
+            next(d.itervalues())
+        except AttributeError:
+            self.fail()
 
     def test_fromkeys(self):
         d = Dict.fromkeys(['a', 'b', 'c', 'd'], redis=self.redis)
-        self.assertEqual(sorted(d.keys()),
-                         ['a', 'b', 'c', 'd'])
-        self.assertEqual(d.values(),
-                         [None] * 4)
+        self.assertEqual(sorted(d.keys()), ['a', 'b', 'c', 'd'])
+        self.assertEqual(d.values(), [None] * 4)
 
         d = Dict.fromkeys(['a', 'b', 'c', 'd'], 'be happy', redis=self.redis)
-        self.assertEqual(sorted(d.keys()),
-                         ['a', 'b', 'c', 'd'])
-        self.assertEqual(d.values(),
-                         ['be happy'] * 4)
+        self.assertEqual(sorted(d.keys()), ['a', 'b', 'c', 'd'])
+        self.assertEqual(d.values(), ['be happy'] * 4)
 
     def test_clear(self):
         d = self.create_dict()
@@ -165,21 +167,26 @@ class DictTest(RedisTestCase):
     def test_update(self):
         d = self.create_dict()
         d['a'] = 'b'
+
         d.update({'c': 'd'})
-        self.assertEqual(sorted(d.items()),
-                         [('a', 'b'), ('c', 'd')])
+        self.assertEqual(sorted(d.items()), [('a', 'b'), ('c', 'd')])
+
         d.update({'c': 42})
-        self.assertEqual(sorted(d.items()),
-                         [('a', 'b'), ('c', 42)])
+        self.assertEqual(sorted(d.items()), [('a', 'b'), ('c', 42)])
+
         d.update({'x': 38})
-        self.assertEqual(sorted(d.items()),
-                         [('a', 'b'), ('c', 42), ('x', 38)])
+        self.assertEqual(
+            sorted(d.items()), [('a', 'b'), ('c', 42), ('x', 38)]
+        )
+
         d.update([('a', 'g')])
-        self.assertEqual(sorted(d.items()),
-                         [('a', 'g'), ('c', 42), ('x', 38)])
+        self.assertEqual(
+            sorted(d.items()), [('a', 'g'), ('c', 42), ('x', 38)]
+        )
         d.update(c=None)
-        self.assertEqual(sorted(d.items()),
-                         [('a', 'g'), ('c', None), ('x', 38)])
+        self.assertEqual(
+            sorted(d.items()), [('a', 'g'), ('c', None), ('x', 38)]
+        )
 
     def test_get_default(self):
         d = self.create_dict()
@@ -235,13 +242,17 @@ class CounterTest(RedisTestCase):
 
     def test_most_common(self):
         c = self.create_counter('abbcccddddeeeeeffffff')
-        counts = [('f', 6), ('e', 5), ('d', 4), ('c', 3), ('b', 2), ('a', 1)]
+        counts = [
+            ('f', 6), ('e', 5), ('d', 4), ('c', 3), ('b', 2), ('a', 1)
+        ]
         self.assertEqual(c.most_common(), counts)
         self.assertEqual(c.most_common(1), counts[0:1])
         self.assertEqual(c.most_common(3), counts[:3])
 
     def test_subtract(self):
-        result = [('a', 0), ('b', 1), ('c', 1), ('d', 2), ('e', 2), ('f', 3)]
+        result = [
+            ('a', 0), ('b', 1), ('c', 1), ('d', 2), ('e', 2), ('f', 3)
+        ]
 
         c1 = self.create_counter('abbcccddddeeeeeffffff')
         c1.subtract('abccddeeefff')
@@ -256,7 +267,9 @@ class CounterTest(RedisTestCase):
         self.assertRaises(NotImplementedError, Counter.fromkeys, [1, 2])
 
     def test_update(self):
-        result = [('a', 2), ('b', 3), ('c', 5), ('d', 6), ('e', 8), ('f', 9)]
+        result = [
+            ('a', 2), ('b', 3), ('c', 5), ('d', 6), ('e', 8), ('f', 9)
+        ]
 
         c1 = self.create_counter('abbcccddddeeeeeffffff')
         c1.update('abccddeeefff')
@@ -270,7 +283,9 @@ class CounterTest(RedisTestCase):
     def test_add(self):
         c1 = self.create_counter('abbcccddddeeeeeffffff')
         c2 = self.create_counter('abccddeeefff')
-        result = [('a', 2), ('b', 3), ('c', 5), ('d', 6), ('e', 8), ('f', 9)]
+        result = [
+            ('a', 2), ('b', 3), ('c', 5), ('d', 6), ('e', 8), ('f', 9)
+        ]
         self.assertEqual(sorted((c1 + c2).items()), sorted(result))
 
     def test_diff(self):
@@ -282,13 +297,17 @@ class CounterTest(RedisTestCase):
     def test_and(self):
         c1 = self.create_counter('abbcccddddeeeeef')
         c2 = self.create_counter('abccddeeefff')
-        result = [('a', 1), ('b', 1), ('c', 2), ('d', 2), ('e', 3), ('f', 1)]
+        result = [
+            ('a', 1), ('b', 1), ('c', 2), ('d', 2), ('e', 3), ('f', 1)
+        ]
         self.assertEqual(sorted((c1 & c2).items()), sorted(result))
 
     def test_or(self):
         c1 = self.create_counter('abbcccddddeeeeef')
         c2 = self.create_counter('abccddeeefff')
-        result = [('a', 1), ('b', 2), ('c', 3), ('d', 4), ('e', 5), ('f', 3)]
+        result = [
+            ('a', 1), ('b', 2), ('c', 3), ('d', 4), ('e', 5), ('f', 3)
+        ]
         self.assertEqual(sorted((c1 | c2).items()), sorted(result))
 
     def test_inc(self):

--- a/tests/test_dicts.py
+++ b/tests/test_dicts.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-
+from __future__ import division, print_function, unicode_literals
 
 import unittest
 
-from .base import RedisTestCase
 from redis_collections import Dict, Counter
+
+from .base import RedisTestCase
 
 
 class DictTest(RedisTestCase):

--- a/tests/test_lists.py
+++ b/tests/test_lists.py
@@ -111,8 +111,10 @@ class ListTest(RedisTestCase):
         l = self.create_list([2013])
         l.extend([4, 5, 6, 7])
         self.assertEqual(list(l), [2013, 4, 5, 6, 7])
+
+        # insert does not replace
         l.insert(0, 3)
-        self.assertEqual(list(l), [3, 2013, 4, 5, 6, 7])    # insert does not replace
+        self.assertEqual(list(l), [3, 2013, 4, 5, 6, 7])
 
     def test_pop_remove(self):
         l = self.create_list([3, 4, 5, 6, 7])
@@ -135,7 +137,7 @@ class ListTest(RedisTestCase):
         self.assertEqual(list(l), [3, 2, 1])
 
     def test_lset_issue(self):
-        for l in ( [1], self.create_list([1]) ):
+        for l in ([1], self.create_list([1])):
             l.insert(0, 5)
             self.assertEqual(list(l), [5, 1])
             l.insert(0, 6)

--- a/tests/test_lists.py
+++ b/tests/test_lists.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-
+from __future__ import division, print_function, unicode_literals
 
 import unittest
 
-from .base import RedisTestCase
 from redis_collections import List
+
+from .base import RedisTestCase
 
 
 class ListTest(RedisTestCase):

--- a/tests/test_sets.py
+++ b/tests/test_sets.py
@@ -198,8 +198,9 @@ class SetTest(RedisTestCase):
         s = self.create_set('a')
         self.assertEqual(s.random_sample(), ['a'])
 
-        version = map(int, self.redis.info()['redis_version'].split('.'))
-        major_ver, minor_ver, _ = version
+        redis_version = self.redis.info()['redis_version']
+        redis_version = [int(x) for x in redis_version.split('.')]
+        major_ver, minor_ver, _ = redis_version
 
         if major_ver >= 2 and minor_ver >= 6:
             s = self.create_set('ab')
@@ -207,7 +208,7 @@ class SetTest(RedisTestCase):
 
     def test_add_unicode(self):
         s = self.create_set()
-        elem = u'ěščřžýáíéůú\U0001F4A9'
+        elem = 'ěščřžýáíéůú\U0001F4A9'
         s.add(elem)
         self.assertEqual(sorted(s), [elem])
 

--- a/tests/test_sets.py
+++ b/tests/test_sets.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-
+from __future__ import division, print_function, unicode_literals
 
 import unittest
 
-from .base import RedisTestCase
 from redis_collections import Set
+
+from .base import RedisTestCase
 
 
 class SetTest(RedisTestCase):


### PR DESCRIPTION
This PR builds upon the ideas in #22 and introduces partial support for Python 3. I'm not ready to consider Python 3 "well-supported" quite yet, as #25 (keys are coerced to strings) is more visible on Python 3.

Notes:
* I went ahead and used `six` as the compatibility layer, rather than writing and testing a custom compatibility layer.
* I've defensively added `__future__` imports for Python 2 to try to keep behaviors between the major versions as similar as possible (I don't think they're doing much work in practice)
* I've made some style changes as recommended by [flake8](http://flake8.pycqa.org/en/latest/). I'm not enforcing flake8-correctness in Travis yet, but probably will eventually.
* Keys get coerced to unicode strings instead of byte strings now. This doesn't mean much on Python 2, but it does make it difficult to retrieve `bytes` objects in Python 3 (previously it was difficult to retrieve `str` objects on Python 3).