### PR TITLE
Allow for non-string keys in Dict classes

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -88,17 +88,8 @@ always use the same Redis connection as the original object::
 Pickling
 --------
 
-If you don't like the standard way of data serialization made by :mod:`pickle`, you can set your own. Use ``pickler`` keyword argument:
-
-    >>> import pickle
-    >>> l = List(pickler=pickle)  # this makes no sense
-
-*pickler* can be anything having two methods (or functions): :func:`dumps` for conversion of data to string, and :func:`loads` for the opposite direction. You can write your own module or class with such interface, or you can use one of those which are already available::
-
-    >>> import json
-    >>> l = List(pickler=json)
-
-New instances of collections coming from operations between them use the same ``pickler``. It is propagated as well as Redis connection.
+If you don't like the standard way of data serialization made by :mod:`pickle`, you may override the ``_pickle`` and ``_unpickle`` methods of the collection classes.
+Using other serializers may limit the objects you can store or retrieve.
 
 Known issues
 --------

--- a/redis_collections/base.py
+++ b/redis_collections/base.py
@@ -113,7 +113,6 @@ class RedisCollection(object):
         """
         assert not isinstance(data, RedisCollection), \
             "Not atomic. Use '_data()' within a transaction first."
-
         cls = cls or self.__class__
         if issubclass(cls, RedisCollection):
             settings = {
@@ -205,7 +204,6 @@ class RedisCollection(object):
         """
         return pickle.loads(string) if string else None
 
-    @abc.abstractmethod
     def _update(self, data, pipe=None):
         """Helper for update operations.
 

--- a/redis_collections/base.py
+++ b/redis_collections/base.py
@@ -56,7 +56,7 @@ class RedisCollection(object):
                     'due to limitations in Redis command set.')
 
     @abc.abstractmethod
-    def __init__(self, data=None, redis=None, key=None, pickler=None):
+    def __init__(self, data=None, redis=None, key=None):
         """
         :param data: Initial data.
         :param redis: Redis client instance. If not provided, default Redis
@@ -66,18 +66,6 @@ class RedisCollection(object):
                     point to the same data. If not provided, default random
                     string is generated.
         :type key: str
-        :param pickler: Implementation of data serialization. Object with two
-                        methods is expected: :func:`dumps` for conversion
-                        of data to string and :func:`loads` for the opposite
-                        direction. Examples::
-
-                            import json, pickle
-                            Dict(pickler=json)
-                            Dict(pickler=pickle)  # default
-
-                        Of course, you can construct your own pickling object
-                        (it can be class, module, whatever). Default
-                        serialization implementation uses :mod:`pickle`.
 
         .. note::
             :func:`uuid.uuid4` is used for default key generation.
@@ -89,10 +77,6 @@ class RedisCollection(object):
         #: Redis client instance. :class:`StrictRedis` object with default
         #: connection settings is used if not set by :func:`__init__`.
         self.redis = redis or self._create_redis()
-
-        #: Class or module implementing pickling. Standard :mod:`pickle`
-        #: module is set as default.
-        self.pickler = pickler or pickle
 
         #: Redis key of the collection.
         self.key = key or self._create_key()
@@ -135,7 +119,6 @@ class RedisCollection(object):
             settings = {
                 'key': key,
                 'redis': self.redis,
-                'pickler': self.pickler,
             }
 
             if pipe is not None and data:
@@ -210,7 +193,7 @@ class RedisCollection(object):
         :type data: anything serializable
         :rtype: string
         """
-        return self.pickler.dumps(data)
+        return pickle.dumps(data)
 
     def _unpickle(self, string):
         """Converts given string serialization back to corresponding data.
@@ -220,12 +203,7 @@ class RedisCollection(object):
         :type string: string
         :rtype: anything serializable
         """
-        if string is None:
-            return None
-        if not isinstance(string, six.binary_type):
-            msg = 'Only strings can be unpickled (%r given).' % string
-            raise TypeError(msg)
-        return self.pickler.loads(string)
+        return pickle.loads(string) if string else None
 
     @abc.abstractmethod
     def _update(self, data, pipe=None):

--- a/redis_collections/dicts.py
+++ b/redis_collections/dicts.py
@@ -550,8 +550,14 @@ class Counter(Dict):
     def __or__(self, other):
         return self._op_helper(other, operator.or_)
 
+    def __ror__(self, other):
+        return self._op_helper(other, operator.or_, swap_args=True)
+
     def __and__(self, other):
         return self._op_helper(other, operator.and_)
+
+    def __rand__(self, other):
+        return self._op_helper(other, operator.and_, swap_args=True)
 
     def __iadd__(self, other):
         return self._op_helper(other, operator.add, inplace=True)

--- a/redis_collections/dicts.py
+++ b/redis_collections/dicts.py
@@ -212,7 +212,7 @@ class Dict(RedisCollection, collections.MutableMapping):
 
             pipe.multi()
             if D:
-                pipe.hset(self.key, key_hash, self.pickle(D))
+                pipe.hset(self.key, key_hash, self._pickle(D))
             else:
                 pipe.hdel(self.key, key_hash)
 

--- a/redis_collections/dicts.py
+++ b/redis_collections/dicts.py
@@ -393,11 +393,26 @@ class Counter(Dict):
     def __missing__(self, key):
         return 0
 
-    most_common = collections.Counter.most_common
+    def most_common(self, n=None):
+        """Return a list of the *n* most common elements and their counts
+        from the most common to the least. If *n* is not specified,
+        :func:`most_common` returns *all* elements in the counter.
+        Elements with equal counts are ordered arbitrarily.
+        """
+        return collections.Counter(self).most_common(n)
 
-    elements = collections.Counter.elements
+    def elements(self, n=None):
+        """Return an iterator over elements repeating each as many times as
+        its count. Elements are returned in arbitrary order. If an element's
+        count is less than one, :func:`elements` will ignore it.
+        """
+        return collections.Counter(self).elements()
 
-    fromkeys = collections.Counter.fromkeys
+    @classmethod
+    def fromkeys(cls, iterable, v=None):
+        raise NotImplementedError(
+            'Counter.fromkeys() is undefined.  Use Counter(iterable) instead.'
+        )
 
     def _update_helper(self, other, op, use_redis=False):
         def _update_helper_trans(pipe):
@@ -541,12 +556,6 @@ class Counter(Dict):
     def __and__(self, other):
         return self._op_helper(other, operator.and_)
 
-    def __pos__(self):
-        return self._op_helper(None, operator.pos)
-
-    def __neg__(self):
-        return self._op_helper(None, operator.neg)
-
     def __iadd__(self, other):
         return self._op_helper(other, operator.add, inplace=True)
 
@@ -558,3 +567,10 @@ class Counter(Dict):
 
     def __iand__(self, other):
         return self._op_helper(other, operator.iand, inplace=True)
+
+    if not six.PY2:
+        def __pos__(self):
+            return self._op_helper(None, operator.pos)
+
+        def __neg__(self):
+            return self._op_helper(None, operator.neg)

--- a/redis_collections/dicts.py
+++ b/redis_collections/dicts.py
@@ -104,15 +104,12 @@ class Dict(RedisCollection, collections.MutableMapping):
         """Return the value for *keys*. If particular key is not in the
         dictionary, return :obj:`None`.
         """
-        ret = []
+        D_subset = {}
         for D in self.redis.hmget(self.key, *(hash(k) for k in keys)):
-            if D is None:
-                ret.append(None)
-            else:
-                for v in six.itervalues(self._unpickle(D)):
-                    ret.append(v)
+            if D is not None:
+                D_subset.update(self._unpickle(D))
 
-        return ret
+        return [D_subset.get(key) for key in keys]
 
     def __getitem__(self, key):
         """Return the item of dictionary with key *key*. Raises a

--- a/redis_collections/dicts.py
+++ b/redis_collections/dicts.py
@@ -51,18 +51,6 @@ class Dict(RedisCollection, collections.MutableMapping):
                     point to the same data. If not provided, default random
                     string is generated.
         :type key: str
-        :param pickler: Implementation of data serialization. Object with two
-                        methods is expected: :func:`dumps` for conversion
-                        of data to string and :func:`loads` for the opposite
-                        direction. Examples::
-
-                            import json, pickle
-                            Dict(pickler=json)
-                            Dict(pickler=pickle)  # default
-
-                        Of course, you can construct your own pickling object
-                        (it can be class, module, whatever). Default
-                        serialization implementation uses :mod:`pickle`.
 
         .. note::
             :func:`uuid.uuid4` is used for default key generation.
@@ -339,9 +327,6 @@ class Counter(Dict):
         argument. Iterable is expected to be a sequence of elements,
         not a sequence of ``(key, value)`` pairs.
 
-        There is no support for *pickler* setting, because all values are
-        integers only.
-
         :param data: Initial data.
         :type data: iterable or mapping
         :param redis: Redis client instance. If not provided, default Redis
@@ -363,8 +348,6 @@ class Counter(Dict):
             As mentioned, :class:`Counter` does not support following
             initialization syntax: ``c = Counter(a=1, b=2)``
         """
-        if 'pickler' in kwargs:
-            del kwargs['pickler']
         super(Counter, self).__init__(*args, **kwargs)
 
     def _pickle(self, data):

--- a/redis_collections/lists.py
+++ b/redis_collections/lists.py
@@ -42,18 +42,6 @@ class List(RedisCollection, collections.MutableSequence):
                     point to the same data. If not provided, default random
                     string is generated.
         :type key: str
-        :param pickler: Implementation of data serialization. Object with two
-                        methods is expected: :func:`dumps` for conversion
-                        of data to string and :func:`loads` for the opposite
-                        direction. Examples::
-
-                            import json, pickle
-                            Dict(pickler=json)
-                            Dict(pickler=pickle)  # default
-
-                        Of course, you can construct your own pickling object
-                        (it can be class, module, whatever). Default
-                        serialization implementation uses :mod:`pickle`.
 
         .. note::
             :func:`uuid.uuid4` is used for default key generation.

--- a/redis_collections/sets.py
+++ b/redis_collections/sets.py
@@ -304,18 +304,6 @@ class Set(RedisCollection, collections.MutableSet):
                     point to the same data. If not provided, default random
                     string is generated.
         :type key: str
-        :param pickler: Implementation of data serialization. Object with two
-                        methods is expected: :func:`dumps` for conversion
-                        of data to string and :func:`loads` for the opposite
-                        direction. Examples::
-
-                            import json, pickle
-                            Dict(pickler=json)
-                            Dict(pickler=pickle)  # default
-
-                        Of course, you can construct your own pickling object
-                        (it can be class, module, whatever). Default
-                        serialization implementation uses :mod:`pickle`.
 
         .. note::
             :func:`uuid.uuid4` is used for default key generation.

--- a/tests/test_dicts.py
+++ b/tests/test_dicts.py
@@ -42,6 +42,9 @@ class DictTest(RedisTestCase):
         d[1] = 'g'
         self.assertEqual(d.getmany('a', 'e', 1.0, 'x'), ['b', 'f', 'g', None])
 
+        if not six.PY2:
+            self.assertEqual(d.getmany(b'a', b'c'), [None, None])
+
     def test_init(self):
         init_seq = [
             ('a', 1),

--- a/tests/test_dicts.py
+++ b/tests/test_dicts.py
@@ -6,6 +6,8 @@ import collections
 import operator
 import unittest
 
+import six
+
 from redis_collections import Dict, Counter
 
 from .base import RedisTestCase
@@ -366,18 +368,6 @@ class CounterTest(RedisTestCase):
         self.assertTrue(isinstance(result, Counter))
         self.assertEqual(result, {'a': 1, 'b': 2, 'c': 2})
 
-    def test_pos(self):
-        redis_counter = self.create_counter({'a': 1, 'b': -2, 'c': 3})
-        python_counter = collections.Counter({'a': 1, 'b': -2, 'c': 3})
-
-        self.assertEqual(+redis_counter, +python_counter)
-
-    def test_neg(self):
-        redis_counter = self.create_counter({'a': 1, 'b': -2, 'c': 3})
-        python_counter = collections.Counter({'a': 1, 'b': -2, 'c': 3})
-
-        self.assertEqual(-redis_counter, -python_counter)
-
     def test_iadd(self):
         redis_counter = self.create_counter('ab')
         python_counter = collections.Counter('ab')
@@ -433,6 +423,19 @@ class CounterTest(RedisTestCase):
         redis_counter &= collections.Counter('cdddd')
         python_counter &= collections.Counter('cdddd')
         self.assertEqual(redis_counter, python_counter)
+
+    if not six.PY2:
+        def test_pos(self):
+            redis_counter = self.create_counter({'a': 1, 'b': -2, 'c': 3})
+            python_counter = collections.Counter({'a': 1, 'b': -2, 'c': 3})
+
+            self.assertEqual(+redis_counter, +python_counter)
+
+        def test_neg(self):
+            redis_counter = self.create_counter({'a': 1, 'b': -2, 'c': 3})
+            python_counter = collections.Counter({'a': 1, 'b': -2, 'c': 3})
+
+            self.assertEqual(-redis_counter, -python_counter)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_dicts.py
+++ b/tests/test_dicts.py
@@ -377,7 +377,7 @@ class CounterTest(RedisTestCase):
             c.update(['a', 'a', 'b', 'b'], c=2)
             self.assertEqual(sorted(c.items()), expected_result)
 
-    def _test_op(self, op, do_reverse=True):
+    def _test_op(self, op):
         redis_counter = self.create_counter('abbccc')
         python_counter = collections.Counter('abbccc')
 
@@ -398,11 +398,9 @@ class CounterTest(RedisTestCase):
         )
 
         # Reversed argument order
-        if do_reverse:
-            self.assertEqual(
-                op(python_other, redis_counter),
-                op(python_other, python_counter)
-            )
+        self.assertEqual(
+            op(python_other, redis_counter), op(python_other, python_counter)
+        )
 
         # Fail for non-counter types
         for c in (redis_counter, python_counter):
@@ -424,14 +422,14 @@ class CounterTest(RedisTestCase):
         self.assertEqual(result, {'c': 1})
 
     def test_or(self):
-        self._test_op(operator.or_, do_reverse=False)
+        self._test_op(operator.or_)
 
         result = self.create_counter('abbccc') | self.create_counter('aabbcc')
         self.assertTrue(isinstance(result, Counter))
         self.assertEqual(result, {'a': 2, 'b': 2, 'c': 3})
 
     def test_and(self):
-        self._test_op(operator.and_, do_reverse=False)
+        self._test_op(operator.and_)
 
         result = self.create_counter('abbccc') & self.create_counter('aabbcc')
         self.assertTrue(isinstance(result, Counter))

--- a/tests/test_dicts.py
+++ b/tests/test_dicts.py
@@ -93,8 +93,7 @@ class DictTest(RedisTestCase):
         d1['c'] = 'd'
         d2 = d1.copy()
         self.assertEqual(d2.__class__, Dict)
-        self.assertEqual(sorted(d1.items()),
-                         sorted(d2.items()))
+        self.assertEqual(sorted(d1.items()), sorted(d2.items()))
 
     def test_get(self):
         d = self.create_dict()


### PR DESCRIPTION
Re: #25, this PR makes fairly drastic changes to the `Dict` and `Counter` classes in `redis_collections.dicts`. The biggest change involves how keys and values are stored in Redis:
* __Before__: A string-ified version of the key is set as the Redis field; a pickled version of the value is set as the Redis value
* __After__: A string-ified version of the `hash(key)` is set as the field; a pickled version of a `dict` mapping the key to the value is set as the Redis value

---

Also in this PR:
* __Custom serialization__: I've removed the ability to set the "pickler" during `Dict` class initialization for simplicity. Custom serialization can be achieved by overriding the `_pickle` and `_unpickle` methods (I may rename those to `_serialize` and `_deserialize`).
* __Counter compatibility__: I've made the `Counter` class more compatible with Python's version. It can accept non-integer values (though I'm not sure why that's allowed in the Python version), and it implements more of the operators with fewer race conditions.
* __Testing enhancements__: I've added several tests in the spirit of #28 - making sure each Redis collection's behavior matches the corresponding Python collection's behavior

---

__Q__: Why not just pickle the keys?
__A__: Because `x == y` and `hash(x) == hash(y)` do not imply `pickle.dumps(x) == pickle.dumps(y)`. This would prevent `Dict({1: 'int', 1.0: 'float'})` from working properly - it should only have one key, `1`, set to `float`.

__Q__: All of this just for that?
__A__: No, there are terrible `str`, `unicode`, and `bytes` issues too. On Python 2 `{u'a': 1, b'a': 2}` results in `{u'a': 2}` and on Python 3 `{b'a': 2, 'a': 1}`.

__Q__: It's a little weird to have the `Counter` operators return Redis collections, isn't it?
__A__: Yes, because you can't set the key for the Redis hash. I will probably change them to return Python `Counters`.

__Q__: What terrible thing are you planning to do next?
__A__: Fix #17 and #26 (sort of).