### PR TITLE
Local caching for mutable values B/W DefaultDict

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,2 @@
+[run]
+include=redis_collections/*

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,7 +8,7 @@ Redis Collections are a set of basic Python collections backed by Redis.
 
 `Redis <http://redis.io/>`_ is a great key-value storage. There is well-designed `client for Python <https://github.com/andymccurdy/redis-py>`_, but sometimes working with it seems to be too *low-level*. You just call methods with names of corresponding Redis commands. Such approach is great when dealing with cutting edge software tasks, but if you write just a simple app or command line script for your own, you might appreciate a bit different interface.
 
-Aim of this small library is to provide such interface when dealing with collections. Redis has support for several types: strings, hashes, lists, sets, sorted sets. Why not to bring them to Python in a *pythonic* way? ::
+The aim of this library is to provide such interface when dealing with collections. Redis has support for several types: strings, hashes, lists, sets, sorted sets. Why not to bring them to Python in a *pythonic* way? ::
 
     >>> from redis_collections import Dict
     >>> d = Dict()
@@ -18,11 +18,9 @@ Aim of this small library is to provide such interface when dealing with collect
     >>> d.items()
     [('answer', 42)]
 
-In my Redis I can see a ``hash`` structure under key ``fe267c1dde5d4f648e7bac836a0168fe``. Using :class:`dict`-like notation, it's value is following::
+In Redis you will see can see a ``hash`` structure under key ``fe267c1dde5d4f648e7bac836a0168fe``. That structure stores a field and value that corresponds to ``{'answer': 42}``.  The value is pickled, because Redis can store only strings.
 
-    {'answer': 'I42\n.'}
-
-The value is pickled, because Redis can store only strings. On Python side, you can do almost any stuff you are used to do with standard :class:`dict` instances:
+On the Python side, you can do most anything you can do with standard :class:`dict` instances:
 
     >>> d.update({'hasek': 39, 'jagr': 68})
     >>> d
@@ -31,7 +29,7 @@ The value is pickled, because Redis can store only strings. On Python side, you 
     >>> d
     <redis_collections.Dict at fe267c1dde5d4f648e7bac836a0168fe {'jagr': 68, 'hasek': 39}>
 
-Every such operation atomically changes data in Redis.
+"Write" operations atomically change data in Redis.
 
 Installation
 ------------
@@ -61,12 +59,12 @@ In case you wish to wipe all its data, use :func:`clear` method, which is availa
 If I look to my Redis, key ``fe267c1dde5d4f648e7bac836a0168fe`` completely disappeared.
 
 .. note::
-    If you provide your own key string, collection will be successfully created. If there is no key corresponding in Redis, it will be created and initialized as an empty collection. This means you can set up your own way of assigning unique keys dependent on your other code. For example, by using IDs of records from your relational database you can have exactly one unique collection in Redis for every record from your SQL storage.
+    If you provide your own key string, a collection will be successfully created. If there is no key corresponding in Redis, it will be created and initialized as an empty collection. This means you can set up your own way of assigning unique keys dependent on your other code. For example, by using IDs of records from your relational database you can have exactly one unique collection in Redis for every record from your SQL storage.
 
 Redis Connection
 ----------------
 
-By default, collection uses a new Redis connection with its default values, **which is highly inefficient, but needs no configuration**. If you wish to use your own :class:`Redis` instance, pass it in ``redis`` keyword argument::
+By default, collections use a new Redis connection with its default values, **which is highly inefficient, but needs no configuration**. If you wish to use your own :class:`Redis` instance, pass it in ``redis`` keyword argument::
 
     >>> from redis import StrictRedis
     >>> r = StrictRedis()
@@ -98,7 +96,7 @@ Known issues
     This can lead to some incompatibilities with Python's ``dict`` - see `issue 25 <https://github.com/honzajavorek/redis-collections/issues/25>`_.
 
 *   Storing a mutable object (like a ``dict``, ``list``, or ``set``) in a ``Dict`` can lead to surprising behavior.
-    If you retrieve the object and then modify it you must explicitly store it again for changes to persist - see `issue 26 <https://github.com/honzajavorek/redis-collections/issues/25>`_.
+    If you retrieve the object and then modify it you must either explicitly store it again for changes to persist, or use the `sync` method.
 
 *   Support for Python 3 is in progress. Please `report <https://github.com/honzajavorek/redis-collections/issues>`_ any issues you find.
 
@@ -141,6 +139,10 @@ Redis Collections are composed of only several classes. All items listed below a
     :special-members:
 
 .. autoclass:: Counter
+    :members:
+    :special-members:
+
+.. autoclass:: DefaultDict
     :members:
     :special-members:
 

--- a/redis_collections/__init__.py
+++ b/redis_collections/__init__.py
@@ -9,7 +9,8 @@ __copyright__ = 'Copyright 2013-? Honza Javorek'
 
 
 from .base import RedisCollection  # NOQA
-
-from .sets import Set  # NOQA
+from .dicts import DefaultDict, Dict, Counter  # NOQA
 from .lists import List  # NOQA
-from .dicts import Dict, Counter  # NOQA
+from .sets import Set  # NOQA
+
+__all__ = ['RedisCollection', 'Set', 'List', 'DefaultDict', 'Dict', 'Counter']

--- a/redis_collections/dicts.py
+++ b/redis_collections/dicts.py
@@ -383,6 +383,13 @@ class Dict(RedisCollection, collections.MutableMapping):
     def _repr_data(self, data):
         return repr(dict(data))
 
+    def __enter__(self):
+        self.writeback = True
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.sync()
+
     def sync(self):
         def sync_trans(pipe):
             D_load = {}

--- a/redis_collections/dicts.py
+++ b/redis_collections/dicts.py
@@ -650,9 +650,56 @@ class Counter(Dict):
 
 
 class DefaultDict(Dict):
-    def __init__(self, default_factory=None, **kwargs):
+    """Mutable **mapping** collection aiming to have the same API as
+    :class:`collections.defaultdict`. See
+    `defaultdict  <https://docs.python.org/2/library/collections.html`_ for
+    further details. The Redis implementation is based on the
+    `hash <http://redis.io/commands#hash>`_ type.
+
+    .. warning::
+        Note that this :class:`DefaultDict` does not implement
+        methods :func:`viewitems`, :func:`viewkeys`, and :func:`viewvalues`,
+        which are available in Python 2.7's version.
+    """
+
+    def __init__(self, *args, **kwargs):
+        """Breakes the original :class:`defaultdict` API, because there is no
+        support for keyword syntax. The only single way to create
+        :class:`defaultdict` object is to pass an iterable or mapping as the
+        second argument.
+
+        :param default_factory: Used to provide default values for missing
+                                keys.
+        :type default_factory: callable or None
+        :param data: Initial data.
+        :type data: iterable or mapping
+        :param redis: Redis client instance. If not provided, default Redis
+                      connection is used.
+        :type redis: :class:`redis.StrictRedis`
+        :param key: Redis key of the collection. Collections with the same key
+                    point to the same data. If not provided, default random
+                    string is generated.
+        :type key: str
+
+        .. note::
+            :func:`uuid.uuid4` is used for default key generation.
+            If you are not satisfied with its `collision
+            probability <http://stackoverflow.com/a/786541/325365>`_,
+            make your own implementation by subclassing and overriding
+            internal method :func:`_create_key`.
+
+        .. warning::
+            As mentioned, :class:`DefaultDict` does not support following
+            initialization syntax: ``d = DefaultDict(None, a=1, b=2)``
+        """
         kwargs.setdefault('writeback', True)
-        super(DefaultDict, self).__init__(**kwargs)
+        if args:
+            default_factory = args[0]
+            args = args[1:]
+        else:
+            default_factory = None
+
+        super(DefaultDict, self).__init__(*args, **kwargs)
 
         if default_factory is None:
             pass

--- a/redis_collections/dicts.py
+++ b/redis_collections/dicts.py
@@ -647,3 +647,29 @@ class Counter(Dict):
 
         def __neg__(self):
             return self._op_helper(None, operator.neg)
+
+
+class DefaultDict(Dict):
+    def __init__(self, default_factory=None, **kwargs):
+        kwargs.setdefault('writeback', True)
+        super(DefaultDict, self).__init__(**kwargs)
+
+        if default_factory is None:
+            pass
+        elif not callable(default_factory):
+            raise TypeError('first argument must be callable or None')
+        self.default_factory = default_factory
+
+    def __missing__(self, key):
+        if self.default_factory is None:
+            raise KeyError(key)
+
+        value = self.default_factory()
+        self[key] = value
+        return value
+
+    def copy(self, **kwargs):
+        other = self.__class__(self.default_factory, **kwargs)
+        other.update(self)
+
+        return other

--- a/tests/test_dicts.py
+++ b/tests/test_dicts.py
@@ -350,6 +350,23 @@ class DictTest(RedisTestCase):
         self.assertEqual(redis_cached._data()['key_7'], [7, 8, 9])
         self.assertEqual(redis_cached.cache['key_7'], [7, 8, 9])
 
+    def test_with(self):
+        with self.create_dict() as D:
+            # Writeback set
+            self.assertTrue(D.writeback)
+
+            # Store a mutable value, modify it, and retrieve it - changes
+            # should be reflected
+            D['key'] = [1]
+            D['key'].append(2)
+            self.assertEqual(D['key'], [1, 2])
+
+            # Changes are not in Redis yet
+            self.assertEqual(D._data()['key'], [1])
+
+        # Closing the context manager syncs to Redis
+        self.assertEqual(D._data()['key'], [1, 2])
+
 
 class CounterTest(RedisTestCase):
 

--- a/tests/test_dicts.py
+++ b/tests/test_dicts.py
@@ -363,6 +363,10 @@ class CounterTest(RedisTestCase):
             c['a'] = 5
             self.assertEqual(c['a'], 5)
 
+            # For whatever reason Python counters accept non-int values
+            c['not integer'] = 'in fact string'
+            self.assertEqual(c['not integer'], 'in fact string')
+
     def test_init(self):
         for init in (self.create_counter, collections.Counter):
             c = init('gallahad')
@@ -460,6 +464,14 @@ class CounterTest(RedisTestCase):
             c = init('abbccc')
             c.update(['a', 'a', 'b', 'b'], c=2)
             self.assertEqual(sorted(c.items()), expected_result)
+
+        # Writeback enabled
+        c = self.create_counter(writeback=True)
+        c[('tuple', 'key')] = 1
+        self.assertIn(('tuple', 'key'), c._data())
+        self.assertIn(('tuple', 'key'), c.cache)
+        c.update({('tuple', 'key'): 2})
+        self.assertEqual(c[('tuple', 'key')], 2)
 
     def _test_op(self, op):
         redis_counter = self.create_counter('abbccc')

--- a/tests/test_dicts.py
+++ b/tests/test_dicts.py
@@ -635,12 +635,18 @@ class DefaultDictTest(RedisTestCase):
                 D = init('not callable')
 
             # Callables are OK
-            D = init(int)
+            D = init(int, {1: 2, 3: 4})
             self.assertEqual(D.default_factory, int)
+            self.assertEqual(D[1], 2)
+            self.assertEqual(D[3], 4)
 
         # Writeback is on for defaultdict
-        D = self.create_ddict()
-        self.assertTrue(D.writeback)
+        D_1 = self.create_ddict()
+        self.assertTrue(D_1.writeback)
+
+        # Keywords are passed through
+        D_2 = self.create_ddict(key=D_1.key)
+        self.assertEqual(D_1.key, D_2.key)
 
     def test_None(self):
         # None is a special case - any misses get a KeyError


### PR DESCRIPTION
Re: #26 and #9, this PR:
* Adds an optional local cache for use when storing mutable objects as `Dict` (and subclass) values
* Adds a Redis-backed `DefaultDict` class

---

__Local cache for mutable values__: See [this comment in issue 26](https://github.com/honzajavorek/redis-collections/issues/26#issuecomment-236079380) for why this cache is needed to support storing things like `dict`, `set`, and `list`.

Until you `sync`, changes to mutable values will not be stored in Redis:
```python
>>> D = Dict({'key': [1, 2]}, writeback=True)
>>> D['key'].append(3)
>>> D['key']  # Read from local cache
0: [1, 2, 3]
>>> D._data()['key']  # Read from Redis - not synced
1: [1, 2]
>>> D.sync()
>>> D._data()['key']  # Read from Redis - synced
2: [1, 2, 3]
```

You may also use a context manager to sync automatically:
```python
... with Dict({'key': [1, 2]}) as D:
...     D['key'].append(3)
...     assert D['key'] == [1, 2, 3]  # Read from local cache
...     assert D._data()['key'] == [1, 2]  # Read from Redis - not synced
... 
... assert D._data()['key'] == [1, 2, 3]  # Automatic sync after with block exits
```

---

__DefaultDict__: This should be familiar to users of the Python version.

```python
>>> D = DefaultDict(lambda: 1)
>>> D[1]  # 1 is not stored, so returns this returns the default value
0: 1
>>> D[1] += 1  # Now it's in the dict
>>> D[1]
1: 2
```

`writeback=True` is automatically set for `DefaultDict`, since it's common to use `defaultdict(list)` and etc. You may sync manually (as above) or use a context manager:
```python
with DefaultDict(list) as D:
    D[0].append(1)
    D[0].append(2)
    assert D[0] == [1, 2]  # Read from local cache
    assert D._data()[0] == []  # Read from Redis - not synced

assert D._data()[0] == [1, 2]  # Read from Redis - synced
```
