### PR TITLE
Python tests B/W List slicing fixes

### DIFF
--- a/redis_collections/lists.py
+++ b/redis_collections/lists.py
@@ -99,7 +99,11 @@ class List(RedisCollection, collections.MutableSequence):
         assert isinstance(index, slice)
 
         def slice_trans(pipe):
-            start, stop = self._recalc_slice(index.start, index.stop)
+            start = index.start or 0
+            if start == index.stop:
+                return []
+            stop = -1 if (index.stop is None) else max(index.stop - 1, 0)
+
             values = pipe.lrange(self.key, start, stop)
             if index.step:
                 # step implemented by pure Python slicing
@@ -108,6 +112,7 @@ class List(RedisCollection, collections.MutableSequence):
 
             pipe.multi()
             return self._create_new(values, pipe=pipe)
+
         return self._transaction(slice_trans)
 
     def __getitem__(self, index):

--- a/tests/test_lists.py
+++ b/tests/test_lists.py
@@ -90,8 +90,7 @@ class ListTest(RedisTestCase):
             self.assertEqual(list(L[2:]), [3])
             self.assertEqual(list(L[3:]), [])
 
-            # TODO - make this test pass
-            # self.assertEqual(list(L[:0]), [])
+            self.assertEqual(list(L[:0]), [])
             self.assertEqual(list(L[:1]), [1])
             self.assertEqual(list(L[:2]), [1, 2])
             self.assertEqual(list(L[:3]), [1, 2, 3])

--- a/tests/test_lists.py
+++ b/tests/test_lists.py
@@ -16,135 +16,169 @@ class ListTest(RedisTestCase):
         return List(*args, **kwargs)
 
     def test_init(self):
-        l = self.create_list([1, 2, 3])
-        self.assertEqual(list(l), [1, 2, 3])
-        l = self.create_list('abc')
-        self.assertEqual(list(l), ['a', 'b', 'c'])
-        l = self.create_list()
-        self.assertEqual(list(l), [])
+        for init in (self.create_list, list):
+            # List from list
+            L = init([1, 2, 3])
+            self.assertEqual(list(L), [1, 2, 3])
+
+            # List from str
+            L = init('abc')
+            self.assertEqual(list(L), ['a', 'b', 'c'])
+
+            # List from bytes
+            L = init(b'abc')
+            self.assertEqual(list(L), [ord('a'), ord('b'), ord('c')])
+
+            # Empty list
+            L = init()
+            self.assertEqual(list(L), [])
 
     def test_in(self):
-        l = self.create_list([1, 2, 3])
-        self.assertTrue(2 in l)
-        self.assertFalse(42 in l)
-        self.assertFalse(2 not in l)
-        self.assertTrue(42 not in l)
+        for init in (self.create_list, list):
+            L = init([1, 2, 3])
+            self.assertIn(2, L)
+            self.assertNotIn(4, L)
 
     def test_concat(self):
-        l1 = self.create_list([1, 2, 3])
-        l2 = self.create_list([1, 4, 5])
-        self.assertEqual(list(l1 + l2), [1, 2, 3, 1, 4, 5])
-        self.assertEqual(list(l1 * 2), [1, 2, 3, 1, 2, 3])
-        self.assertEqual(list(2 * l1), [1, 2, 3, 1, 2, 3])
-        self.assertEqual(list(l1 * 0), [])
-        self.assertEqual(list(l1 * -1), [])
+        for init in (self.create_list, list):
+            L_1 = init([1, 2, 3])
+            L_2 = init([1, 4, 5])
+            self.assertEqual(list(L_1 + L_2), [1, 2, 3, 1, 4, 5])
+            self.assertEqual(list(L_1 * 2), [1, 2, 3, 1, 2, 3])
+            self.assertEqual(list(2 * L_1), [1, 2, 3, 1, 2, 3])
+            self.assertEqual(list(L_1 * 2), [1, 2, 3, 1, 2, 3])
+            self.assertEqual(list(L_1 * 0), [])
+            self.assertEqual(list(L_1 * -1), [])
 
     def test_set_get_overflow(self):
-        l = self.create_list([1, 2, 3])
+        L = self.create_list([1, 2, 3])
 
-        def get_overflow(l):
-            return l[42]
+        with self.assertRaises(IndexError):
+            L[42]
 
-        def set_overflow(l):
-            l[42] = 5
+        with self.assertRaises(IndexError):
+            L[42] = 4
 
-        self.assertRaises(IndexError, get_overflow, l)
-        self.assertRaises(IndexError, set_overflow, l)
-        self.assertEqual(l.get(42), None)
-        self.assertEqual(l.get(1), 2)
+        self.assertEqual(L.get(42), None)
+        self.assertEqual(L.get(1), 2)
 
     def test_index_count(self):
-        l = self.create_list([1, 2, 3])
-        self.assertEqual(l[0], 1)
-        self.assertEqual(l[1], 2)
-        self.assertEqual(l[2], 3)
-        self.assertEqual(l[-1], 3)
-        self.assertEqual(l[-2], 2)
-        self.assertEqual(l[-3], 1)
-        self.assertRaises(IndexError, lambda: l[42])
-        self.assertRaises(IndexError, lambda: l[-42])
+        for init in (self.create_list, list):
+            L = init([1, 2, 3])
+            self.assertEqual(L[0], 1)
+            self.assertEqual(L[1], 2)
+            self.assertEqual(L[2], 3)
+            self.assertEqual(L[-1], 3)
+            self.assertEqual(L[-2], 2)
+            self.assertEqual(L[-3], 1)
+            self.assertRaises(IndexError, lambda: L[42])
+            self.assertRaises(IndexError, lambda: L[-42])
 
-        l = self.create_list([1, 2, 3, 2, 3])
-        self.assertEqual(l.index(2), 1)
-        self.assertEqual(l.index(2, 2), 3)
-        self.assertRaises(ValueError, l.index, 2, 2, 3)
-        self.assertEqual(l.count(2), 2)
+            L = init([1, 2, 3, 2, 3])
+            self.assertEqual(L.index(2), 1)
+            self.assertEqual(L.index(2, 2), 3)
+            self.assertRaises(ValueError, L.index, 2, 2, 3)
+            self.assertEqual(L.count(2), 2)
 
     def test_slice(self):
-        l = self.create_list([1, 2, 3])
-        self.assertEqual(list(l[0:1]), [1])
-        self.assertEqual(list(l[0:2]), [1, 2])
-        self.assertEqual(list(l[:]), [1, 2, 3])
-        self.assertEqual(list(l[0:-1]), [1, 2])
-        self.assertEqual(list(l[1:]), [2, 3])
-        self.assertEqual(list(l[1::1]), [2, 3])
-        self.assertEqual(list(l[1::2]), [2])
+        for init in (self.create_list, list):
+            L = init([1, 2, 3])
+            self.assertEqual(list(L[:]), [1, 2, 3])
+
+            self.assertEqual(list(L[0:]), [1, 2, 3])
+            self.assertEqual(list(L[1:]), [2, 3])
+            self.assertEqual(list(L[2:]), [3])
+            self.assertEqual(list(L[3:]), [])
+
+            # TODO - make this test pass
+            # self.assertEqual(list(L[:0]), [])
+            self.assertEqual(list(L[:1]), [1])
+            self.assertEqual(list(L[:2]), [1, 2])
+            self.assertEqual(list(L[:3]), [1, 2, 3])
+            self.assertEqual(list(L[:4]), [1, 2, 3])
 
     def test_len_min_max(self):
-        l = self.create_list([1, 2, 3])
-        self.assertEqual(len(l), 3)
-        self.assertEqual(min(l), 1)
-        self.assertEqual(max(l), 3)
+        for init in (self.create_list, list):
+            L = init([1, 2, 3])
+            self.assertEqual(len(L), 3)
+            self.assertEqual(min(L), 1)
+            self.assertEqual(max(L), 3)
+
+            self.assertEqual(len(init([])), 0)
 
     def test_mutable(self):
-        l = self.create_list([1, 2, 3])
-        l[2] = 42
-        self.assertEqual(l[2], 42)
-        l[1:] = []
-        self.assertEqual(list(l), [1])
-        l.append(2013)
-        self.assertEqual(list(l), [1, 2013])
+        for init in (self.create_list, list):
+            L = init([1, 2, 3])
+            L[2] = 42
+            self.assertEqual(L[2], 42)
+
+            L[1:] = []
+            self.assertEqual(list(L), [1])
+
+            L.append(2013)
+            self.assertEqual(list(L), [1, 2013])
 
     def test_del(self):
-        l = self.create_list([1, 2013])
-        del l[0]
-        self.assertEqual(list(l), [2013])
-        del l[1:]
-        self.assertEqual(list(l), [2013])
-        l.append(5)
-        self.assertEqual(list(l), [2013, 5])
-        l[1] = 8
-        self.assertEqual(list(l), [2013, 8])
-        del l[1:]
-        self.assertEqual(list(l), [2013])
+        for init in (self.create_list, list):
+            L = init([1, 2013])
+
+            del L[0]
+            self.assertEqual(list(L), [2013])
+
+            del L[1:]
+            self.assertEqual(list(L), [2013])
+
+            L.append(5)
+            self.assertEqual(list(L), [2013, 5])
+
+            L[1] = 8
+            self.assertEqual(list(L), [2013, 8])
+
+            del L[1:]
+            self.assertEqual(list(L), [2013])
 
     def test_extend_insert(self):
-        l = self.create_list([2013])
-        l.extend([4, 5, 6, 7])
-        self.assertEqual(list(l), [2013, 4, 5, 6, 7])
+        for init in (self.create_list, list):
+            L = init([2013])
+            L.extend([4, 5, 6, 7])
+            self.assertEqual(list(L), [2013, 4, 5, 6, 7])
 
-        # insert does not replace
-        l.insert(0, 3)
-        self.assertEqual(list(l), [3, 2013, 4, 5, 6, 7])
+            # insert does not replace
+            L.insert(0, 3)
+            self.assertEqual(list(L), [3, 2013, 4, 5, 6, 7])
 
     def test_pop_remove(self):
-        l = self.create_list([3, 4, 5, 6, 7])
-        self.assertEqual(l.pop(), 7)
-        self.assertEqual(list(l), [3, 4, 5, 6])
-        self.assertEqual(l.pop(0), 3)
-        self.assertEqual(list(l), [4, 5, 6])
-        l.extend([4, 5, 6])
-        l.remove(4)
-        self.assertEqual(list(l), [5, 6, 4, 5, 6])
+        for init in (self.create_list, list):
+            L = init([3, 4, 5, 6, 7])
+            self.assertEqual(L.pop(), 7)
+            self.assertEqual(list(L), [3, 4, 5, 6])
+            self.assertEqual(L.pop(0), 3)
+            self.assertEqual(list(L), [4, 5, 6])
+            L.extend([4, 5, 6])
+            L.remove(4)
+            self.assertEqual(list(L), [5, 6, 4, 5, 6])
 
     def test_slice_trim(self):
-        l = self.create_list([5, 6, 4, 5, 6])
-        l[2:] = []
-        self.assertEqual(list(l), [5, 6])
+        for init in (self.create_list, list):
+            L = init([5, 6, 4, 5, 6])
+            L[2:] = []
+            self.assertEqual(list(L), [5, 6])
 
     def test_reverse(self):
-        l = self.create_list([1, 2, 3])
-        l.reverse()
-        self.assertEqual(list(l), [3, 2, 1])
+        for init in (self.create_list, list):
+            L = init([1, 2, 3])
+            L.reverse()
+            self.assertEqual(list(L), [3, 2, 1])
 
     def test_lset_issue(self):
-        for l in ([1], self.create_list([1])):
-            l.insert(0, 5)
-            self.assertEqual(list(l), [5, 1])
-            l.insert(0, 6)
-            self.assertEqual(list(l), [6, 5, 1])
-            l.append(7)
-            self.assertEqual(list(l), [6, 5, 1, 7])
+        for init in (self.create_list, list):
+            L = init([1])
+            L.insert(0, 5)
+            self.assertEqual(list(L), [5, 1])
+            L.insert(0, 6)
+            self.assertEqual(list(L), [6, 5, 1])
+            L.append(7)
+            self.assertEqual(list(L), [6, 5, 1, 7])
 
 
 if __name__ == '__main__':

--- a/tests/test_lists.py
+++ b/tests/test_lists.py
@@ -4,6 +4,8 @@ from __future__ import division, print_function, unicode_literals
 
 import unittest
 
+import six
+
 from redis_collections import List
 
 from .base import RedisTestCase
@@ -27,7 +29,10 @@ class ListTest(RedisTestCase):
 
             # List from bytes
             L = init(b'abc')
-            self.assertEqual(list(L), [ord('a'), ord('b'), ord('c')])
+            if six.PY2:
+                self.assertEqual(list(L), [b'a', b'b', b'c'])
+            else:
+                self.assertEqual(list(L), [ord('a'), ord('b'), ord('c')])
 
             # Empty list
             L = init()

--- a/tests/test_lists.py
+++ b/tests/test_lists.py
@@ -81,20 +81,43 @@ class ListTest(RedisTestCase):
             self.assertEqual(L.count(2), 2)
 
     def test_slice(self):
-        for init in (self.create_list, list):
-            L = init([1, 2, 3])
-            self.assertEqual(list(L[:]), [1, 2, 3])
+        redis_list = self.create_list([0, 1, 2, 3])
+        python_list = [0, 1, 2, 3]
 
-            self.assertEqual(list(L[0:]), [1, 2, 3])
-            self.assertEqual(list(L[1:]), [2, 3])
-            self.assertEqual(list(L[2:]), [3])
-            self.assertEqual(list(L[3:]), [])
-
-            self.assertEqual(list(L[:0]), [])
-            self.assertEqual(list(L[:1]), [1])
-            self.assertEqual(list(L[:2]), [1, 2])
-            self.assertEqual(list(L[:3]), [1, 2, 3])
-            self.assertEqual(list(L[:4]), [1, 2, 3])
+        for index in [
+            slice(None, None),  # L[:]
+            slice(0, None, None),  # L[0:]
+            slice(1, None, None),  # L[1:]
+            slice(3, None, None),  # L[3:]
+            slice(4, None, None),  # L[4:]
+            slice(None, 0, None),  # L[:0]
+            slice(None, 1, None),  # L[:1]
+            slice(None, 3, None),  # L[:3]
+            slice(None, 4, None),  # L[:3]
+            slice(0, 0, None),  # L[0:0]
+            slice(1, 1, None),  # L[1:1]
+            slice(3, 3, None),  # L[3:3]
+            slice(3, 3, None),  # L[3:3]
+            slice(-1, None, None),  # L[-1:]
+            slice(-2, None, None),  # L[-2:]
+            slice(-4, None, None),  # L[-4:]
+            slice(None, -1, None),  # L[-1:]
+            slice(None, -2, None),  # L[-2:]
+            slice(None, -4, None),  # L[-4:]
+            slice(0, -1, None),  # L[0:-1]
+            slice(1, -1, None),  # L[1:-1]
+            slice(1, -2, None),  # L[1:-2]
+            slice(-3, -1, None),  # L[-3:-1]
+            slice(None, None, 1),  # L[::1]
+            slice(None, None, 2),  # L[::2]
+            slice(None, None, 3),  # L[::3]
+            slice(None, None, 4),  # L[::4]
+            slice(None, None, -1),  # L[::-1]
+            slice(None, None, -2),  # L[::-2]
+            slice(1, -1, 2),  # L[1:-1:1]
+            slice(1, -1, -2),  # L[1:-1:-2]
+        ]:
+            self.assertEqual(list(redis_list[index]), python_list[index])
 
     def test_len_min_max(self):
         for init in (self.create_list, list):

--- a/tests/test_sets.py
+++ b/tests/test_sets.py
@@ -16,183 +16,213 @@ class SetTest(RedisTestCase):
         return Set(*args, **kwargs)
 
     def test_init(self):
-        s = self.create_set([1, 2, 3])
-        self.assertEqual(sorted(s), [1, 2, 3])
-        s = self.create_set('abc')
-        self.assertEqual(sorted(s), ['a', 'b', 'c'])
-        s = self.create_set('antananarivo')
-        self.assertEqual(sorted(s), ['a', 'i', 'n', 'o', 'r', 't', 'v'])
-        s = self.create_set()
-        self.assertEqual(sorted(s), [])
+        for init in (self.create_set, set):
+            s = init([1, 2, 3])
+            self.assertEqual(sorted(s), [1, 2, 3])
+
+            s = init('abc')
+            self.assertEqual(sorted(s), ['a', 'b', 'c'])
+
+            s = init('antananarivo')
+            self.assertEqual(sorted(s), ['a', 'i', 'n', 'o', 'r', 't', 'v'])
+
+            s = init()
+            self.assertEqual(sorted(s), [])
 
     def test_len(self):
-        s = self.create_set([1, 2, 3, 3])
-        self.assertEqual(len(s), 3)
+        for init in (self.create_set, set):
+            s = init([1, 2, 3, 3])
+            self.assertEqual(len(s), 3)
 
     def test_in(self):
-        s = self.create_set([1, 2, 3, 3])
-        self.assertEqual(1 in s, True)
-        self.assertEqual(42 in s, False)
-        self.assertEqual(1 not in s, False)
-        self.assertEqual(42 not in s, True)
+        for init in (self.create_set, set):
+            s = init([1, 2, 3, 3])
+            self.assertEqual(1 in s, True)
+            self.assertEqual(42 in s, False)
+            self.assertEqual(1 not in s, False)
+            self.assertEqual(42 not in s, True)
 
     def test_equal(self):
-        s1 = self.create_set([1, 2, 3, 3])
-        s2 = self.create_set([4, 5])
-        s3 = self.create_set([4, 5])
-        self.assertFalse(s1 == s2)
-        self.assertTrue(s1 != s3)
-        self.assertTrue(s2 == s3)
-        self.assertTrue(s3 == s3)
+        for init in (self.create_set, set):
+            s_1 = init([1, 2, 3, 3])
+            s_2 = init([4, 5])
+            s_3 = init([4, 5])
+            self.assertNotEqual(s_1, s_3)
+            self.assertNotEqual(s_1, s_3)
+            self.assertEqual(s_2, s_3)
+            self.assertEqual(s_3, s_3)
 
     def test_disjoint(self):
-        s1 = self.create_set([1, 2, 3, 3])
-        s2 = self.create_set([4, 5])
-        self.assertTrue(s1.isdisjoint(s2))
+        for init in (self.create_set, set):
+            s_1 = init([1, 2, 3, 3])
+            s_2 = init([4, 5])
+            self.assertTrue(s_1.isdisjoint(s_2))
 
     def test_subset(self):
-        s1 = self.create_set([1, 2, 3, 3])
-        s2 = self.create_set([4, 5])
-        self.assertFalse(s2.issubset(s1))
-        s2 = self.create_set([3, 2])
-        self.assertTrue(s2.issubset(s1))
-        self.assertTrue(s2 <= s1)
-        self.assertTrue(s2 < s1)
-        s2 = self.create_set([1, 2, 3, 3])
-        self.assertFalse(s2 < s1)
+        for init in (self.create_set, set):
+            s_1 = init([1, 2, 3, 3])
+            s_2 = init([4, 5])
+            self.assertFalse(s_2.issubset(s_1))
+
+            s_2 = init([3, 2])
+            self.assertTrue(s_2.issubset(s_1))
+            self.assertTrue(s_2 <= s_1)
+            self.assertTrue(s_2 < s_1)
+
+            s_2 = init([1, 2, 3, 3])
+            self.assertFalse(s_2 < s_1)
 
     def test_superset(self):
-        s1 = self.create_set([1, 2, 3, 3])
-        s2 = self.create_set([4, 5])
-        self.assertFalse(s2.issuperset(s1))
-        s2 = self.create_set([3, 2])
-        self.assertTrue(s1.issuperset(s2))
-        self.assertTrue(s1 >= s2)
-        self.assertTrue(s1 > s2)
-        s2 = self.create_set([1, 2, 3, 3])
-        self.assertFalse(s1 > s2)
+        for init in (self.create_set, set):
+            s_1 = init([1, 2, 3, 3])
+            s_2 = init([4, 5])
+            self.assertFalse(s_2.issuperset(s_1))
+
+            s_2 = init([3, 2])
+            self.assertTrue(s_1.issuperset(s_2))
+            self.assertTrue(s_1 >= s_2)
+            self.assertTrue(s_1 > s_2)
+
+            s_2 = init([1, 2, 3, 3])
+            self.assertFalse(s_1 > s_2)
 
     def test_union(self):
-        s1 = self.create_set([1, 2, 3, 3])
-        s2 = self.create_set([4, 5])
-        s3 = set([6])
-        l = [6]
-        self.assertEqual(sorted(s1 | s2), [1, 2, 3, 4, 5])
-        self.assertEqual(sorted(s1.union(s2)), [1, 2, 3, 4, 5])
-        self.assertEqual(sorted(s1 | s2 | s3), [1, 2, 3, 4, 5, 6])
-        self.assertEqual(sorted(s1.union(s2, s3)), [1, 2, 3, 4, 5, 6])
-        self.assertRaises(TypeError, lambda: s1 | s2 | l)
-        self.assertEqual(sorted(s1.union(s2, l)), [1, 2, 3, 4, 5, 6])
+        for init in (self.create_set, set):
+            s_1 = init([1, 2, 3, 3])
+            s_2 = init([4, 5])
+            s_3 = set([6])
+            l = [6]
+            self.assertEqual(sorted(s_1 | s_2), [1, 2, 3, 4, 5])
+            self.assertEqual(sorted(s_1.union(s_2)), [1, 2, 3, 4, 5])
+            self.assertEqual(sorted(s_1 | s_2 | s_3), [1, 2, 3, 4, 5, 6])
+            self.assertEqual(sorted(s_1.union(s_2, s_3)), [1, 2, 3, 4, 5, 6])
+            self.assertRaises(TypeError, lambda: s_1 | s_2 | l)
+            self.assertEqual(sorted(s_1.union(s_2, l)), [1, 2, 3, 4, 5, 6])
 
     def test_intersection(self):
-        s1 = self.create_set([1, 2, 3, 3])
-        s2 = self.create_set([3, 4, 5])
-        s3 = set([6])
-        l = [6]
-        self.assertEqual(sorted(s1 & s2), [3])
-        self.assertEqual(sorted(s1.intersection(s2)), [3])
-        self.assertEqual(sorted(s1 & s2 & s3), [])
-        self.assertEqual(sorted(s1.intersection(s2, s3)), [])
-        self.assertRaises(TypeError, lambda: s1 & s2 & l)
-        self.assertEqual(sorted(s1.intersection(s2, l)), [])
-        self.assertEqual(sorted(s3 & s2), [])
+        for init in (self.create_set, set):
+            s_1 = init([1, 2, 3, 3])
+            s_2 = init([3, 4, 5])
+            s_3 = set([6])
+            l = [6]
+            self.assertEqual(sorted(s_1 & s_2), [3])
+            self.assertEqual(sorted(s_1.intersection(s_2)), [3])
+            self.assertEqual(sorted(s_1 & s_2 & s_3), [])
+            self.assertEqual(sorted(s_1.intersection(s_2, s_3)), [])
+            self.assertRaises(TypeError, lambda: s_1 & s_2 & l)
+            self.assertEqual(sorted(s_1.intersection(s_2, l)), [])
+            self.assertEqual(sorted(s_3 & s_2), [])
 
     def test_difference(self):
-        s1 = self.create_set([1, 2, 3, 3])
-        s2 = self.create_set([3, 4, 5])
-        s3 = set([6])
-        l = [6]
-        self.assertEqual(sorted(s1 - s2), [1, 2])
-        self.assertEqual(sorted(s1.difference(s2)), [1, 2])
-        self.assertEqual(sorted(s1 - s2 - s3), [1, 2])
-        self.assertEqual(sorted(s1.difference(s2, s3)), [1, 2])
-        self.assertRaises(TypeError, lambda: s1 - s2 - l)
-        self.assertEqual(sorted(s1.difference(s2, l)), [1, 2])
-        self.assertEqual(sorted(s3 - s1), [6])
+        for init in (self.create_set, set):
+            s_1 = init([1, 2, 3, 3])
+            s_2 = init([3, 4, 5])
+            s_3 = set([6])
+            l = [6]
+            self.assertEqual(sorted(s_1 - s_2), [1, 2])
+            self.assertEqual(sorted(s_1.difference(s_2)), [1, 2])
+            self.assertEqual(sorted(s_1 - s_2 - s_3), [1, 2])
+            self.assertEqual(sorted(s_1.difference(s_2, s_3)), [1, 2])
+            self.assertRaises(TypeError, lambda: s_1 - s_2 - l)
+            self.assertEqual(sorted(s_1.difference(s_2, l)), [1, 2])
+            self.assertEqual(sorted(s_3 - s_1), [6])
 
     def test_symmetric_difference(self):
-        s1 = self.create_set([1, 2, 3, 3])
-        s2 = self.create_set([3, 4, 5])
-        s3 = set([6])
-        l = [6]
-        self.assertEqual(sorted(s1 ^ s2), [1, 2, 4, 5])
-        self.assertEqual(sorted(s1.symmetric_difference(s2)), [1, 2, 4, 5])
-        self.assertEqual(sorted(s1 ^ s2 ^ s3), [1, 2, 4, 5, 6])
-        self.assertRaises(TypeError, lambda: s1 ^ s2 ^ l)
-        self.assertEqual(sorted(s3 ^ s1 ^ s2), [1, 2, 4, 5, 6])
+        for init in (self.create_set, set):
+            s_1 = init([1, 2, 3, 3])
+            s_2 = init([3, 4, 5])
+            s_3 = set([6])
+            l = [6]
+            self.assertEqual(sorted(s_1 ^ s_2), [1, 2, 4, 5])
+            self.assertEqual(
+                sorted(s_1.symmetric_difference(s_2)), [1, 2, 4, 5]
+            )
+            self.assertEqual(sorted(s_1 ^ s_2 ^ s_3), [1, 2, 4, 5, 6])
+            self.assertRaises(TypeError, lambda: s_1 ^ s_2 ^ l)
+            self.assertEqual(sorted(s_3 ^ s_1 ^ s_2), [1, 2, 4, 5, 6])
 
     def test_copy(self):
-        s1 = self.create_set('abc')
-        s2 = s1.copy()
-        self.assertEqual(s2.__class__, Set)
-        self.assertEqual(sorted(s1),
-                         sorted(s2))
+        for init in (self.create_set, set):
+            s_1 = init('abc')
+            s_2 = s_1.copy()
+            self.assertEqual(s_1.__class__, s_2.__class__)
+            self.assertEqual(sorted(s_1), sorted(s_2))
 
     def test_result_type(self):
-        s1 = self.create_set('ab')
-        s2 = set('bc')
-        s3 = s1 | s2
-        s4 = s2 | s1
-        self.assertEqual(s3.__class__, s1.__class__)
-        self.assertEqual(s4.__class__, s2.__class__)
+        for init in (self.create_set, set):
+            s_1 = init('ab')
+            s_2 = set('bc')
+            s_3 = s_1 | s_2
+            s4 = s_2 | s_1
+            self.assertEqual(s_3.__class__, s_1.__class__)
+            self.assertEqual(s4.__class__, s_2.__class__)
 
     def test_update(self):
-        s1 = self.create_set('ab')
-        s2 = frozenset('bc')
-        st = 'cd'
-        s1 |= s2
-        self.assertEqual(sorted(s1), ['a', 'b', 'c'])
-        s1.update(s2, st)
-        self.assertEqual(sorted(s1), ['a', 'b', 'c', 'd'])
+        for init in (self.create_set, set):
+            s_1 = init('ab')
+            s_2 = frozenset('bc')
+            st = 'cd'
+            s_1 |= s_2
+            self.assertEqual(sorted(s_1), ['a', 'b', 'c'])
+            s_1.update(s_2, st)
+            self.assertEqual(sorted(s_1), ['a', 'b', 'c', 'd'])
 
     def test_intersection_update(self):
-        s1 = self.create_set('ab')
-        s2 = frozenset('bc')
-        st = 'cd'
-        s1 &= s2
-        self.assertEqual(sorted(s1), ['b'])
-        s1.intersection_update(s2, st)
-        self.assertEqual(sorted(s1), [])
+        for init in (self.create_set, set):
+            s_1 = init('ab')
+            s_2 = frozenset('bc')
+            st = 'cd'
+            s_1 &= s_2
+            self.assertEqual(sorted(s_1), ['b'])
+            s_1.intersection_update(s_2, st)
+            self.assertEqual(sorted(s_1), [])
 
     def test_difference_update(self):
-        s1 = self.create_set('ab')
-        s2 = frozenset('bc')
-        st = 'cd'
-        s1 -= s2
-        self.assertEqual(sorted(s1), ['a'])
-        s1.difference_update(s2, st)
-        self.assertEqual(sorted(s1), ['a'])
+        for init in (self.create_set, set):
+            s_1 = init('ab')
+            s_2 = frozenset('bc')
+            s_3 = 'cd'
+            s_1 -= s_2
+            self.assertEqual(sorted(s_1), ['a'])
+            s_1.difference_update(s_2, s_3)
+            self.assertEqual(sorted(s_1), ['a'])
 
     def test_symmetric_difference_update(self):
-        s1 = self.create_set('ab')
-        s2 = frozenset('bc')
-        st = 'cd'
-        s1 ^= s2
-        self.assertEqual(sorted(s1), ['a', 'c'])
-        s1.symmetric_difference_update(st)
-        self.assertEqual(sorted(s1), ['a', 'd'])
+        for init in (self.create_set, set):
+            s_1 = init('ab')
+            s_2 = frozenset('bc')
+            s_3 = 'cd'
+            s_1 ^= s_2
+            self.assertEqual(sorted(s_1), ['a', 'c'])
+            s_1.symmetric_difference_update(s_3)
+            self.assertEqual(sorted(s_1), ['a', 'd'])
 
     def test_add(self):
         s = self.create_set('ab')
         s.add('c')
         self.assertEqual(sorted(s), ['a', 'b', 'c'])
+
+        # Returning True or False after addition isn't something the native
+        # Python `set` does
         self.assertFalse(s.add('c'))
         self.assertTrue(s.add('d'))
 
     def test_remove_discard(self):
-        s = self.create_set('cdab')
-        self.assertRaises(KeyError, s.remove, 'x')
-        s.remove('b')
-        self.assertEqual(sorted(s), ['a', 'c', 'd'])
-        s.discard('x')
-        s.discard('a')
-        self.assertEqual(sorted(s), ['c', 'd'])
+        for init in (self.create_set, set):
+            s = init('cdab')
+            self.assertRaises(KeyError, s.remove, 'x')
+            s.remove('b')
+            self.assertEqual(sorted(s), ['a', 'c', 'd'])
+            s.discard('x')
+            s.discard('a')
+            self.assertEqual(sorted(s), ['c', 'd'])
 
     def test_pop(self):
-        s = self.create_set('a')
-        self.assertEqual(s.pop(), 'a')
-        self.assertEqual(sorted(s), [])
-        self.assertRaises(KeyError, s.pop)
+        for init in (self.create_set, set):
+            s = init('a')
+            self.assertEqual(s.pop(), 'a')
+            self.assertEqual(sorted(s), [])
+            self.assertRaises(KeyError, s.pop)
 
     def test_random_sample(self):
         s = self.create_set('a')
@@ -207,15 +237,17 @@ class SetTest(RedisTestCase):
             self.assertEqual(sorted(s.random_sample(2)), ['a', 'b'])
 
     def test_add_unicode(self):
-        s = self.create_set()
-        elem = 'ěščřžýáíéůú\U0001F4A9'
-        s.add(elem)
-        self.assertEqual(sorted(s), [elem])
+        for init in (self.create_set, set):
+            s = init()
+            elem = 'ěščřžýáíéůú\U0001F4A9'
+            s.add(elem)
+            self.assertEqual(sorted(s), [elem])
 
     def test_clear(self):
-        s = self.create_set('abcdefg')
-        s.clear()
-        self.assertEqual(sorted(s), [])
+        for init in (self.create_set, set):
+            s = self.create_set('abcdefg')
+            s.clear()
+            self.assertEqual(sorted(s), [])
 
 
 class _Set(Set):


### PR DESCRIPTION
Re: #28, this augments the tests for `List` and `Set` such that most operations are also tested against `list` and `set`. (This is already done this for most of the `Dict` operations)

This revealed some problems with list slicing, in particular when the slice's `start` and `stop` were equal (should return an empty list) and when all three of `start`, `stop`, and `step` are not `None` (`L[i:j:k] != L[i:j][::k]` in many cases).