### PR TITLE
Add coveralls testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,20 @@
 sudo: false
+
 language: "python"
+
 python:
     - "2.7"
     - "3.3"
     - "3.4"
     - "3.5"
-script: "python -m unittest discover"
+
+script:
+    - "pip install --upgrade coveralls"
+    - "coverage run -m unittest discover"
+
 services:
     - "redis-server"
+
 deploy:
   provider: "pypi"
   user: "honzajavorek"
@@ -17,3 +24,6 @@ deploy:
     python: "2.7"
     tags: true
     repo: "honzajavorek/redis-collections"
+
+after_success:
+    - "coveralls"

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,5 +25,8 @@ deploy:
     tags: true
     repo: "honzajavorek/redis-collections"
 
+notifications:
+  email: false
+
 after_success:
     - "coveralls"

--- a/README.rst
+++ b/README.rst
@@ -5,6 +5,10 @@ Redis Collections
 .. image:: https://travis-ci.org/honzajavorek/redis-collections.svg
    :target: https://travis-ci.org/honzajavorek/redis-collections
 
+.. image:: https://coveralls.io/repos/github/honzajavorek/redis-collections/badge.svg?branch=master
+   :target: https://coveralls.io/github/honzajavorek/redis-collections?branch=master
+
+
 Set of basic Python collections backed by Redis.
 
 Installation


### PR DESCRIPTION
This PR adds test coverage tracking with Coveralls.io - see first build's data [here](https://coveralls.io/builds/7322056). This will help point out where tests might be helpful, a la #28.