### PR TITLE
Add writeback and sync for List

### DIFF
--- a/redis_collections/dicts.py
+++ b/redis_collections/dicts.py
@@ -98,9 +98,12 @@ class Dict(RedisCollection, collections.MutableMapping):
 
         return ret
 
-    def __iter__(self):
+    def __iter__(self, pipe=None):
         """Return an iterator over the keys of the dictionary."""
-        return self.iterkeys()
+        pipe = pipe or self.redis
+        for D in six.itervalues(pipe.hgetall(self.key)):
+            for k in six.iterkeys(self._unpickle(D)):
+                yield k
 
     def __contains__(self, key):
         """Return ``True`` if *key* is present, else ``False``."""

--- a/redis_collections/dicts.py
+++ b/redis_collections/dicts.py
@@ -52,6 +52,10 @@ class Dict(RedisCollection, collections.MutableMapping):
                     point to the same data. If not provided, default random
                     string is generated.
         :type key: str
+        :param writeback: If ``True`` keep a local cache of changes for storing
+                          modifications to mutable values. Changes will be
+                          written to Redis after calling the ``sync`` method.
+        :type key: bool
 
         .. note::
             :func:`uuid.uuid4` is used for default key generation.

--- a/redis_collections/lists.py
+++ b/redis_collections/lists.py
@@ -80,7 +80,7 @@ class List(RedisCollection, collections.MutableSequence):
 
     def __reversed__(self):
         """Returns iterator for the sequence in reversed order."""
-        return reversed(list(self._data()))
+        return reversed(list(self.__iter__()))
 
     def _recalc_slice(self, start, stop):
         """Slicing in Redis takes also the item at 'stop' index, so there is

--- a/redis_collections/lists.py
+++ b/redis_collections/lists.py
@@ -185,8 +185,11 @@ class List(RedisCollection, collections.MutableSequence):
                 return self.cache[cache_index]
 
         pickled_value = self.redis.lindex(self.key, index)
+        if pickled_value is None:
+            value = default
+        else:
+            value = self._unpickle(pickled_value)
 
-        value = self._unpickle(pickled_value)
         if self.writeback:
             self.cache[cache_index] = value
         return value

--- a/tests/test_lists.py
+++ b/tests/test_lists.py
@@ -226,6 +226,12 @@ class ListTest(RedisTestCase):
         python_list[0]['one'] = 2
 
         self.assertEqual(redis_cached[0], python_list[0])
+        self.assertEqual(
+            list(redis_cached), list(python_list)
+        )
+        self.assertEqual(
+            list(reversed(redis_cached)), list(reversed(python_list))
+        )
 
         # Changes are not reflected in Redis until after sync
         self.assertNotEqual(list(redis_cached._data())[0], python_list[0])

--- a/tests/test_lists.py
+++ b/tests/test_lists.py
@@ -64,7 +64,8 @@ class ListTest(RedisTestCase):
         with self.assertRaises(IndexError):
             L[42] = 4
 
-        self.assertEqual(L.get(42), None)
+        self.assertIsNone(L.get(42))
+        self.assertEqual(L.get(42, 'MISSING'), 'MISSING')
         self.assertEqual(L.get(1), 2)
 
     def test_index_count(self):

--- a/tests/test_lists.py
+++ b/tests/test_lists.py
@@ -133,7 +133,7 @@ class ListTest(RedisTestCase):
 
             self.assertEqual(len(init([])), 0)
 
-    def test_mutable(self):
+    def test_modify(self):
         for init in (self.create_list, list):
             L = init([1, 2, 3])
             L[2] = 42
@@ -163,6 +163,9 @@ class ListTest(RedisTestCase):
 
             del L[1:]
             self.assertEqual(list(L), [2013])
+
+            del L[:]
+            self.assertEqual(list(L), [])
 
     def test_extend_insert(self):
         for init in (self.create_list, list):
@@ -207,6 +210,127 @@ class ListTest(RedisTestCase):
             L.append(7)
             self.assertEqual(list(L), [6, 5, 1, 7])
 
+    def test_reversed(self):
+        for init in (self.create_list, list):
+            L = init([0, 1, 2, 3])
+            self.assertEqual(list(reversed(L)), [3, 2, 1, 0])
+
+    def test_mutable(self):
+        redis_cached = self.create_list(writeback=True)
+        python_list = []
+
+        redis_cached.append({'one': 1})
+        python_list.append({'one': 1})
+
+        redis_cached[0]['one'] = 2
+        python_list[0]['one'] = 2
+
+        self.assertEqual(redis_cached[0], python_list[0])
+
+        # Changes are not reflected in Redis until after sync
+        self.assertNotEqual(list(redis_cached._data())[0], python_list[0])
+        redis_cached.sync()
+        self.assertEqual(list(redis_cached._data())[0], python_list[0])
+        self.assertEqual(redis_cached.cache, {})
+
+    def test_cache(self):
+        redis_cached = self.create_list(writeback=True)
+
+        # append
+        redis_cached.append([])
+        redis_cached[0].append('whartnell')
+
+        redis_cached.append([])
+        redis_cached[1].append('ptroughton')
+
+        redis_cached.append([])
+        redis_cached[2].append('jpertwee')
+
+        self.assertEqual(
+            redis_cached.cache,
+            {0: ['whartnell'], 1: ['ptroughton'], 2: ['jpertwee']}
+        )
+
+        # __iter__
+        self.assertEqual(
+            list(redis_cached),
+            [['whartnell'], ['ptroughton'], ['jpertwee']]
+        )
+
+        # __getitem__
+        self.assertEqual(redis_cached[0], ['whartnell'])
+        self.assertEqual(redis_cached[1], ['ptroughton'])
+        self.assertEqual(redis_cached[2], ['jpertwee'])
+
+        self.assertEqual(redis_cached[-3], ['whartnell'])
+        self.assertEqual(redis_cached[-2], ['ptroughton'])
+        self.assertEqual(redis_cached[-1], ['jpertwee'])
+
+        # get
+        self.assertEqual(redis_cached.get(0), ['whartnell'])
+
+        # __setitem__
+        redis_cached.append(None)
+        redis_cached[3] = ['tbaker']
+        self.assertEqual(redis_cached[3], ['tbaker'])
+
+        # __delitem__
+        del redis_cached[-1]
+        self.assertEqual(len(redis_cached), 3)
+
+        del redis_cached[0]
+        self.assertEqual(len(redis_cached), 2)
+        self.assertEqual(redis_cached.cache[0], ['ptroughton'])
+
+        # insert
+        redis_cached.insert(0, ['whartnell'])
+        self.assertEqual(len(redis_cached), 3)
+        self.assertEqual(redis_cached.cache[0], ['whartnell'])
+        self.assertEqual(redis_cached.cache[1], ['ptroughton'])
+
+        # index
+        redis_cached.append([None])
+        redis_cached.append([None])
+        redis_cached.append([None])
+        redis_cached[3][0] = 'tbaker'
+        redis_cached[4][0] = 'tbaker'
+        redis_cached[5][0] = 'pdavison'
+
+        self.assertEqual(redis_cached.index(['tbaker']), 3)
+        self.assertEqual(redis_cached.index(['tbaker'], 4), 4)
+        with self.assertRaises(ValueError):
+                redis_cached.index(['tbaker'], 0, 2)
+
+        # remove (forces sync)
+        redis_cached.remove(['tbaker'])
+        self.assertEqual(len(redis_cached), 5)
+        self.assertEqual(list(redis_cached)[3:], [['tbaker'], ['pdavison']])
+
+        # extend
+        redis_cached.extend([['cbaker'], ['smccoy'], ['pmcgann', 'jhurt']])
+        self.assertEqual(len(redis_cached), 8)
+        self.assertEqual(redis_cached[4], ['pdavison'])
+        self.assertEqual(redis_cached[5], ['cbaker'])
+        self.assertEqual(redis_cached[6], ['smccoy'])
+        self.assertEqual(redis_cached[7], ['pmcgann', 'jhurt'])
+
+        # pop
+        redis_cached.insert(0, ['morbius'])
+        self.assertEqual(redis_cached.pop(0), ['morbius'])
+        self.assertEqual(redis_cached[0], ['whartnell'])
+        self.assertEqual(len(redis_cached), 8)
+
+        redis_cached.append(['ceccleston'])
+        self.assertEqual(redis_cached.pop(), ['ceccleston'])
+        self.assertEqual(len(redis_cached), 8)
+
+    def test_with(self):
+        with self.create_list(writeback=True) as redis_cached:
+            redis_cached.append({'one': 1})
+            redis_cached[0]['one'] = 2
+            self.assertEqual(list(redis_cached._data())[0], {'one': 1})
+
+        self.assertEqual(list(redis_cached._data())[0], {'one': 2})
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Re: #52, this PR adds the `writeback` and `sync` methods to `List`, plus context manager support.

This was a bit trickier than it was with `Dict`, due to index management.

```python
>>> from redis_collections import List
... 
... with List() as L:
...     L.append(set())
...     L[0].add(1)
... 
... print(list(L))
[{1}]
```