### PR TITLE
Specify encoding since README.rst has unicode in it

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
     name=meta['title'],
     version=meta['version'],
     description='Set of basic Python collections backed by Redis.',
-    long_description=open('README.rst').read(),
+    long_description=open('README.rst', encoding='utf-8').read(),
     author=meta['author'],
     author_email='mail@honzajavorek.cz',
     url='https://github.com/honzajavorek/redis-collections',


### PR DESCRIPTION
`README.rst` has some Unicode in it so on systems that have a preferred encoding of ascii installation fails with a `UnicodeDecodeError`. This specifies the encoding to be utf-8.