### PR TITLE
List improvements

### DIFF
--- a/redis_collections/dicts.py
+++ b/redis_collections/dicts.py
@@ -98,9 +98,12 @@ class Dict(RedisCollection, collections.MutableMapping):
 
         return ret
 
-    def __iter__(self):
+    def __iter__(self, pipe=None):
         """Return an iterator over the keys of the dictionary."""
-        return self.iterkeys()
+        pipe = pipe or self.redis
+        for D in six.itervalues(pipe.hgetall(self.key)):
+            for k in six.iterkeys(self._unpickle(D)):
+                yield k
 
     def __contains__(self, key):
         """Return ``True`` if *key* is present, else ``False``."""

--- a/redis_collections/lists.py
+++ b/redis_collections/lists.py
@@ -185,7 +185,7 @@ class List(RedisCollection, collections.MutableSequence):
             # Steps must be done index by index
             if index.step is not None:
                 pipe.multi()
-                for i in six.moves.xrange(start, stop, step):
+                for i in list(six.moves.xrange(len_self))[index]:
                     pipe.lset(self.key, i, self.__marker)
                 pipe.lrem(self.key, 0, self.__marker)
             # Slice covers entire range: delete the whole list
@@ -193,14 +193,14 @@ class List(RedisCollection, collections.MutableSequence):
                 self.clear(pipe)
             # Slice starts on the left: keep the right
             elif start == 0 and stop != len_self:
-                pipe.ltrim(self.key, stop + 1, -1)
-            # Slice stops on the right: kep the left
+                pipe.ltrim(self.key, stop, -1)
+            # Slice stops on the right: keep the left
             elif start != 0 and stop == len_self:
                 pipe.ltrim(self.key, 0, start - 1)
             # Slice starts and ends in the middle
             else:
-                left_values = pipe.lrange(self.key, 0, max(start - 2, 0))
-                right_values = pipe.lrange(self.key, stop + 1, -1)
+                left_values = pipe.lrange(self.key, 0, start - 1)
+                right_values = pipe.lrange(self.key, stop, -1)
                 pipe.delete(self.key)
                 all_values = itertools.chain(left_values, right_values)
                 pipe.rpush(self.key, *all_values)

--- a/redis_collections/lists.py
+++ b/redis_collections/lists.py
@@ -348,6 +348,7 @@ class List(RedisCollection, collections.MutableSequence):
         if index == 0:
             self.redis.lpush(self.key, self._pickle(value))
             if self.writeback:
+                self.cache = {k + 1: v for k, v in six.iteritems(self.cache)}
                 self.cache[0] = value
         # Almost as easy case: insert on the right
         elif index == -1:

--- a/redis_collections/lists.py
+++ b/redis_collections/lists.py
@@ -10,6 +10,8 @@ from __future__ import division, print_function, unicode_literals
 import collections
 
 import six
+from redis import ResponseError
+import uuid
 
 from .base import RedisCollection
 
@@ -56,420 +58,212 @@ class List(RedisCollection, collections.MutableSequence):
             make your own implementation by subclassing and overriding
             internal method :func:`_create_key`.
         """
+        data = args[0] if args else kwargs.pop('data', None)
         writeback = kwargs.pop('writeback', False)
         super(List, self).__init__(*args, **kwargs)
 
+        self.__marker = uuid.uuid4().hex
         self.writeback = writeback
         self.cache = {}
 
-    def _get_cache_index(self, index):
-        return index if index >= 0 else self.__len__() + index
+        if data:
+            self.extend(data)
 
-    def __len__(self):
-        """Length of the sequence."""
-        return self.redis.llen(self.key)
+    def _normalize_index(self, index, pipe=None):
+        pipe = pipe or self.redis
+        len_self = pipe.llen(self.key)
+        positive_index = index if index >= 0 else len_self + index
 
-    def _data(self, pipe=None):
-        redis = pipe if pipe is not None else self.redis
-        values = redis.lrange(self.key, 0, -1)
-        return (self._unpickle(v) for v in values)
-
-    def __iter__(self):
-        """Return an iterator over the sequence."""
-        return (self.cache.get(i, x) for i, x in enumerate(self._data()))
-
-    def __reversed__(self):
-        """Returns iterator for the sequence in reversed order."""
-        return reversed(list(self.__iter__()))
-
-    def _recalc_slice(self, start, stop):
-        """Slicing in Redis takes also the item at 'stop' index, so there is
-        some recalculation to be done. Method returns tuple ``(start, stop)``
-        where both values are recalculated to numbers in Redis terms.
-
-        :param start: Index starting the range (in Python terms).
-        :param stop: Index where the range ends (in Python terms).
-        """
-        start = start or 0
-        if stop is None:
-            stop = -1
-        else:
-            stop = stop - 1 if stop != 0 else stop
-        return start, stop
-
-    def _calc_overflow(self, size, index):
-        """Index overflow detection. Returns :obj:`True` if *index* is out of
-        range for the given *size*. Otherwise returns :obj:`False`.
-
-        :param size: Size of the collection.
-        :param index: Index to be examined.
-        """
-        return (index >= size) if (index >= 0) else (abs(index) > size)
-
-    def _get_slice(self, index):
-        """Helper for getting a slice."""
-        assert isinstance(index, slice)
-
-        # For slices without a step we can use the Redis range function
-        def slice_trans(pipe):
-            calc_start, calc_stop = self._recalc_slice(index.start, index.stop)
-            if calc_start == index.stop:
-                return []
-
-            values = []
-            redis_values = pipe.lrange(self.key, calc_start, calc_stop)
-            for i, v in enumerate(redis_values, index.start or 0):
-                values.append(self.cache.get(i, self._unpickle(v)))
-
-            pipe.multi()
-            return self._create_new(values, pipe=pipe)
-
-        # Otherwise we'll need to pull the whole list and slice in Python
-        def step_trans(pipe):
-            values = []
-            redis_values = pipe.lrange(self.key, 0, -1)
-            for i, v in enumerate(redis_values):
-                values.append(self.cache.get(i, self._unpickle(v)))
-
-            values = values[index.start:index.stop:index.step]
-            pipe.multi()
-            return self._create_new(values, pipe=pipe)
-
-        if index.step:
-            return self._transaction(step_trans)
-        return self._transaction(slice_trans)
-
-    def __getitem__(self, index):
-        """Returns item of sequence on *index*.
-        Origin of indexes is 0. Accepts also slicing.
-
-        .. note::
-            Due to implementation on Redis side, ``l[index]`` is not very
-            efficient operation. If possible, use :func:`get`. Slicing without
-            steps is efficient. Steps are implemented only on Python side.
-        """
-        if isinstance(index, slice):
-            return self._get_slice(index)
-
-        if self.writeback:
-            cache_index = self._get_cache_index(index)
-            if cache_index in self.cache:
-                return self.cache[cache_index]
-
-        with self.redis.pipeline() as pipe:
-            pipe.llen(self.key)
-            pipe.lindex(self.key, index)
-            size, pickled_value = pipe.execute()
-
-        if self._calc_overflow(size, index):
-            raise IndexError(index)
-
-        value = self._unpickle(pickled_value)
-        if self.writeback:
-            self.cache[cache_index] = value
-        return value
-
-    def get(self, index, default=None):
-        """Return the value for *index* if *index* is not out of range, else
-        *default*. If *default* is not given, it defaults to :obj:`None`, so
-        that this method never raises a :exc:`IndexError`.
-
-        .. note::
-            Due to implementation on Redis side, this method of retrieving
-            items is more efficient than classic approach over using the
-            :func:`__getitem__` protocol.
-        """
-        if self.writeback:
-            cache_index = self._get_cache_index(index)
-            if cache_index in self.cache:
-                return self.cache[cache_index]
-
-        pickled_value = self.redis.lindex(self.key, index)
-
-        value = self._unpickle(pickled_value)
-        if self.writeback:
-            self.cache[cache_index] = value
-        return value
-
-    def _set_slice(self, index, value):
-        """Helper for setting a slice."""
-        assert isinstance(index, slice)
-
-        if value:
-            # assigning anything else than empty lists not supported
-            raise NotImplementedError(self.not_impl_msg)
-
-        self.__delitem__(index)
-
-    def __setitem__(self, index, value):
-        """Item of *index* is replaced by *value*.
-
-        .. warning::
-            Slicing is generally not supported. Only empty lists are accepted
-            if the operation leads into trimming::
-
-                l[2:] = []
-                l[:2] = []
-                l[:] = []
-        """
-        if isinstance(index, slice):
-            return self._set_slice(index, value)
-
-        def set_trans(pipe):
-            size = pipe.llen(self.key)
-            if self._calc_overflow(size, index):
-                raise IndexError(index)
-            pipe.multi()
-            pipe.lset(self.key, index, self._pickle(value))
-
-        self._transaction(set_trans)
-
-        if self.writeback:
-            cache_index = self._get_cache_index(index)
-            self.cache[cache_index] = value
-
-    def _del_slice(self, index):
-        """Helper for deleting a slice."""
-        assert isinstance(index, slice)
-
-        begin = 0
-        end = -1
-
-        if index.step:
-            # stepping not supported
-            raise NotImplementedError(self.not_impl_msg)
-
-        start, stop = self._recalc_slice(index.start, index.stop)
-
-        if start == begin and stop == end:
-            # trim from beginning to end
-            self.clear()
-            self.cache.clear()
-            return
-
-        with self.redis.pipeline() as pipe:
-            if self.writeback:
-                self._sync_helper(pipe)
-            if start != begin and stop == end:
-                # right trim
-                pipe.ltrim(self.key, begin, start - 1)
-            elif start == begin and stop != end:
-                # left trim
-                pipe.ltrim(self.key, stop + 1, end)
-            else:
-                # only trimming is supported
-                raise NotImplementedError(self.not_impl_msg)
-            pipe.execute()
+        return len_self, positive_index
 
     def __delitem__(self, index):
-        """Item of *index* is deleted.
-
-        .. warning::
-            Slicing is generally not supported. Only empty lists are accepted
-            if the operation leads into trimming::
-
-                del l[2:]
-                del l[:2]
-                del l[:]
-        """
-        begin = 0
-        end = -1
-
-        # Calculate the cache index before the length changes
-        if self.writeback:
-            cache_index = self._get_cache_index(index)
-
         if isinstance(index, slice):
-            return self._del_slice(index)
+            raise NotImplementedError
 
-        if index == begin:
-            self.redis.lpop(self.key)
-        elif index == end:
-            self.redis.rpop(self.key)
-        else:
-            raise NotImplementedError(self.not_impl_msg)
-
-        # Removing an item from the list means all the other items after it
-        # have to shift back one - reflect that in the cache
-        if self.writeback:
-            new_cache = {}
-            for k, v in six.iteritems(self.cache):
-                if k < cache_index:
-                    new_cache[k] = v
-                elif k == cache_index:
-                    pass
-                elif k > cache_index:
-                    new_cache[k - 1] = v
-
-            self.cache = new_cache
-
-    def remove(self, value):
-        """Remove the first occurence of *value*."""
-        # If we're caching, we'll need to synchronize before removing.
-        with self.redis.pipeline() as pipe:
-            if self.writeback:
-                self._sync_helper(pipe)
-            pipe.lrem(self.key, 1, self._pickle(value))
-            pipe.execute()
-
-    def index(self, value, start=None, stop=None):
-        """Returns index of the first occurence of *value*.
-
-        If *start* or *stop* are provided, returns the smallest
-        index such that ``s[index] == value`` and ``start <= index < stop``.
-        """
-        for k, v in six.iteritems(self.cache):
-            if v == value:
-                if start is not None and k < start:
-                    continue
-                if stop is not None and k >= stop:
-                    break
-                return k
-
-        start, stop = self._recalc_slice(start, stop)
-        values = self.redis.lrange(self.key, start, stop)
-
-        for i, v in enumerate(self._unpickle(v) for v in values):
-            if v == value:
-                return i + start
-        raise ValueError(value)
-
-    def count(self, value):
-        """Returns number of occurences of *value*.
-
-        .. note::
-            Implemented only on Python side.
-        """
-        ret = 0
-        for k, v in enumerate(self._data()):
-            v = self.cache.get(k, v)
-            if v == value:
-                ret += 1
-
-        return ret
-
-    def insert(self, index, value):
-        """Insert *value* before *index*. Can only work with index == 0.
-        """
-        if index != 0:
-            # Redis has no commands for *inserting* into a list by index.
-            # LINSERT requires assumptions about contents of the list values.
-            raise NotImplementedError(self.not_impl_msg)
-
-        self.redis.lpush(self.key, self._pickle(value))
-
-        if self.writeback:
-            new_cache = {k + 1: v for k, v in six.iteritems(self.cache)}
-            new_cache[0] = value
-            self.cache = new_cache
-
-    def append(self, value):
-        """Insert *value* at end of list.
-        """
-        i = self.redis.rpush(self.key, self._pickle(value))
-
-        if self.writeback:
-            self.cache[i - 1] = value
-
-    def _update(self, data, pipe=None):
-        super(List, self)._update(data, pipe)
-        redis = pipe if pipe is not None else self.redis
-
-        values = [self._pickle(x) for x in data]
-        return redis.rpush(self.key, *values)
-
-    def extend(self, values):
-        """*values* are appended at the end of the list. Any iterable
-        is accepted.
-        """
-        if isinstance(values, RedisCollection):
-            # wrap into transaction
-            def extend_trans(pipe):
-                d = values._data(pipe=pipe)  # retrieve
-                pipe.multi()
-                return self._update(d, pipe=pipe)  # store
-            new_len = self._transaction(extend_trans)
-        else:
-            new_len = self._update(values)
-
-        if self.writeback:
-            for k, v in enumerate(values, new_len - len(values)):
-                self.cache[k] = v
-
-    def pop(self, index=-1):
-        """Item on *index* is removed and returned.
-
-        .. warning::
-            Only indexes ``0`` and ``-1`` (default) are supported, otherwise
-            :exc:`NotImplementedError` is raised.
-        """
-        # Calculate the cache index before the length changes
-        if self.writeback:
-            cache_index = self._get_cache_index(index)
-
+        # Easy case: remove from the left
         if index == 0:
-            value = self._unpickle(self.redis.lpop(self.key))
+            self.redis.lpop(self.key)
+            if self.writeback:
+                items = six.iteritems(self.cache)
+                self.cache = {i - 1: v for i, v in items if i != 0}
+        # Slightly harder case: remove from the right
         elif index == -1:
-            value = self._unpickle(self.redis.rpop(self.key))
+            if self.writeback:
+                def delitem_right_trans(pipe):
+                    __, cache_index = self._normalize_index(index, pipe)
+                    pipe.multi()
+                    pipe.rpop(self.key)
+                    items = six.iteritems(self.cache)
+                    self.cache = {i: v for i, v in items if i != cache_index}
+                self._transaction(delitem_right_trans)
+            else:
+                self.redis.rpop(self.key)
+        # Sort of hard case: remove from the middle.
+        # Set index to marker value, then remove the item with that value
         else:
-            raise NotImplementedError(self.not_impl_msg)
+            def delitem_middle_trans(pipe):
+                if self.writeback:
+                    __, cache_index = self._normalize_index(index, pipe)
+                try:
+                    pipe.lset(self.key, index, self.__marker)
+                except ResponseError:
+                    raise IndexError('list assignment index out of range')
+                pipe.lrem(self.key, 1, self.__marker)
 
-        # Removing an item from the list means all the other items after it
-        # have to shift back one - reflect that in the cache
+                if self.writeback:
+                    new_cache = {}
+                    for i, v in six.iteritems(self.cache):
+                        if i < cache_index:
+                            new_cache[i] = v
+                        elif i > cache_index:
+                            new_cache[i - 1] = v
+                    self.cache = new_cache
+            self._transaction(delitem_middle_trans)
+
+    def __getitem__(self, index):
+        if isinstance(index, slice):
+            raise NotImplementedError
+
+        def getitem_trans(pipe):
+            len_self, cache_index = self._normalize_index(index, pipe)
+
+            if (cache_index < 0) or (cache_index >= len_self):
+                raise IndexError('list index out of range')
+
+            if cache_index in self.cache:
+                return cache_index, self.cache[cache_index]
+
+            value = self._unpickle(pipe.lindex(self.key, index))
+            return cache_index, value
+
+        cache_index, value = self._transaction(getitem_trans)
+
         if self.writeback:
-            new_cache = {}
-            for k, v in six.iteritems(self.cache):
-                if k < cache_index:
-                    new_cache[k] = v
-                elif k == cache_index:
-                    value = v
-                elif k > cache_index:
-                    new_cache[k - 1] = v
-
-            self.cache = new_cache
-
+            self.cache[cache_index] = value
         return value
 
-    def __add__(self, values):
-        """Returns concatenation of the list and given iterable. New
-        :class:`List` instance is returned.
-        """
-        def add_trans(pipe):
+    def _data(self, pipe=None):
+        pipe = pipe or self.redis
+        return [self._unpickle(v) for v in pipe.lrange(self.key, 0, -1)]
+
+    def __iter__(self, pipe=None):
+        return (self.cache.get(i, v) for i, v in enumerate(self._data(pipe)))
+
+    def __len__(self):
+        return self.redis.llen(self.key)
+
+    def __reversed__(self):
+        return reversed(list(self.__iter__()))
+
+    def __setitem__(self, index, value):
+        if isinstance(index, slice):
+            raise NotImplementedError
+
+        with self.redis.pipeline() as pipe:
             if self.writeback:
-                self._sync_helper(pipe)
+                __, cache_index = self._normalize_index(index, pipe)
 
-            d1 = list(self._data(pipe=pipe))  # retrieve
+            pipe.lset(self.key, index, self._pickle(value))
 
-            if isinstance(values, RedisCollection):
-                d2 = list(values._data(pipe=pipe))  # retrieve
+            try:
+                pipe.execute()
+            except ResponseError:
+                raise IndexError('list assignment index out of range')
+
+            if self.writeback:
+                self.cache[cache_index] = value
+
+    def append(self, value):
+        len_self = self.redis.rpush(self.key, self._pickle(value))
+
+        if self.writeback:
+            self.cache[len_self - 1] = value
+
+    def clear(self, value):
+        self.redis.delete(self.key)
+
+        if self.writeback:
+            self.cache.clear()
+
+    def count(self, value):
+        return sum(1 for v in self.__iter__() if v == value)
+
+    def insert(self, index, value):
+        # Easy case: insert on the left
+        if index == 0:
+            self.redis.lpush(self.key, self._pickle(value))
+            if self.writeback:
+                self.cache[0] = value
+        # Almost as easy case: insert on the right
+        elif index == -1:
+            len_self = self.redis.rpush(self.key, self._pickle(value))
+            if self.writeback:
+                cache_index = index if index >= 0 else len_self + index
+                self.cache[cache_index] = value
+        # Difficult case: insert in the middle.
+        # Retrieve everything from ``index`` up to the end, insert ``value``
+        # on the right, then re-insert the retrieved items on the right
+        else:
+            def insert_middle_trans(pipe):
+                __, cache_index = self._normalize_index(index, pipe)
+                right_values = pipe.lrange(self.key, cache_index, -1)
+                pipe.ltrim(self.key, 0, cache_index - 1)
+                pipe.rpush(self.key, self._pickle(value), *right_values)
+                if self.writeback:
+                    new_cache = {}
+                    for i, v in six.iteritems(self.cache):
+                        if i < cache_index:
+                            new_cache[i] = v
+                        elif i >= cache_index:
+                            new_cache[i + 1] = v
+                    new_cache[cache_index] = value
+                    self.cache = new_cache
+            self._transaction(insert_middle_trans)
+
+    def extend(self, other):
+        def extend_trans(pipe):
+            if use_redis:
+                values = list(other.__iter__(pipe))
             else:
-                d2 = list(values)
-
-            pipe.multi()
-            return self._create_new(d1 + d2, pipe=pipe)  # store
-        return self._transaction(add_trans)
-
-    def __radd__(self, values):
-        return self.__add__(values)
-
-    def __mul__(self, n):
-        """Returns *n* copies of the list, concatenated. New :class:`List`
-        instance is returned.
-        """
-        if not isinstance(n, int):
-            raise TypeError('Cannot multiply sequence by non-int.')
-
-        def mul_trans(pipe):
+                values = other
+            len_self = pipe.rpush(self.key, *(self._pickle(v) for v in values))
             if self.writeback:
-                self._sync_helper(pipe)
+                for i, v in enumerate(values, len_self - len(values)):
+                    self.cache[i] = v
 
-            data = list(self._data(pipe=pipe))  # retrieve
-            pipe.multi()
-            return self._create_new(data * n, pipe=pipe)  # store
-        return self._transaction(mul_trans)
+        if isinstance(other, RedisCollection):
+            use_redis = True
+            self._transaction(extend_trans, other.key)
+        else:
+            use_redis = False
+            self._transaction(extend_trans)
 
-    def __rmul__(self, n):
-        return self.__mul__(n)
+    def index(self, value, start=None, stop=None):
+        def index_trans(pipe):
+            len_self, normal_start = self._normalize_index(start or 0, pipe)
+            __, normal_stop = self._normalize_index(stop or len_self, pipe)
+            for i, v in enumerate(self.__iter__(pipe=pipe)):
+                if v == value:
+                    if i < normal_start:
+                        continue
+                    if i >= normal_stop:
+                        break
+                    return i
+            raise ValueError('{} is not in list'.format(value))
+
+        return self._transaction(index_trans)
+
+    def pop(self, index=-1):
+        pass
+
+    def remove(self, value):
+        pass
+
+    def reverse(self):
+        pass
+
+    def __iadd__(self):
+        pass
 
     def _repr_data(self, data):
         return repr(list(data))
@@ -482,14 +276,14 @@ class List(RedisCollection, collections.MutableSequence):
         self.sync()
 
     def _sync_helper(self, pipe):
-        for k, v in six.iteritems(self.cache):
-            pipe.lset(self.key, k, self._pickle(v))
+        for i, v in six.iteritems(self.cache):
+            pipe.lset(self.key, i, self._pickle(v))
 
         self.cache = {}
 
     def sync(self):
         def sync_trans(pipe):
-            pipe.multi()
+            # pipe.multi()
             self._sync_helper(pipe)
 
         self._transaction(sync_trans)

--- a/redis_collections/sets.py
+++ b/redis_collections/sets.py
@@ -322,9 +322,9 @@ class Set(RedisCollection, collections.MutableSet):
         redis = pipe if pipe is not None else self.redis
         return (self._unpickle(v) for v in redis.smembers(self.key))
 
-    def __iter__(self):
+    def __iter__(self, pipe=None):
         """Return an iterator over elements of the set."""
-        return self._data()
+        return self._data(pipe)
 
     def __contains__(self, elem):
         """Test for membership of *elem* in the set."""

--- a/tests/test_lists.py
+++ b/tests/test_lists.py
@@ -340,5 +340,14 @@ class ListTest(RedisTestCase):
 
         self.assertEqual(list(redis_cached._data())[0], {'one': 2})
 
+    def test_imul(self):
+        values = ('zero', 'one', 'two', 'three')
+        for times in (-1, 0, 1, 2):
+            redis_list = self.create_list(values)
+            python_list = list(values)
+            redis_list *= times
+            python_list *= times
+            self.assertEqual(list(redis_list), python_list)
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_lists.py
+++ b/tests/test_lists.py
@@ -64,8 +64,10 @@ class ListTest(RedisTestCase):
         with self.assertRaises(IndexError):
             L[42] = 4
 
-        self.assertEqual(L.get(42), None)
-        self.assertEqual(L.get(1), 2)
+        with self.assertRaises(IndexError):
+            L[42]
+
+        self.assertEqual(L[1], 2)
 
     def test_index_count(self):
         for init in (self.create_list, list):
@@ -273,7 +275,7 @@ class ListTest(RedisTestCase):
         self.assertEqual(redis_cached[-1], ['jpertwee'])
 
         # get
-        self.assertEqual(redis_cached.get(0), ['whartnell'])
+        # self.assertEqual(redis_cached.get(0), ['whartnell'])
 
         # __setitem__
         redis_cached.append(None)

--- a/tests/test_lists.py
+++ b/tests/test_lists.py
@@ -36,13 +36,25 @@ class ListTest(RedisTestCase):
             self.assertIn(3, L)
             self.assertNotIn(4, L)
 
-    def test_delitem(self):
-        data = (0, 1, 2, 3)
+    def test_get_set_del_index(self):
+        data = ('zero', 'one', 'two', 'three')
         for i in (0, 1, 2, 3, -1, -2, -3, -4):
             redis_list = self.create_list(data)
             redis_cached = self.create_list(data, writeback=True)
             python_list = list(data)
 
+            # Get the values
+            self.assertEqual(redis_list[i], python_list[i], i)
+            self.assertEqual(redis_cached[i], python_list[i], i)
+
+            # Set the values and get them again
+            redis_list[i] = i
+            redis_cached[i] = i
+            python_list[i] = i
+            self.assertEqual(redis_list[i], python_list[i], i)
+            self.assertEqual(redis_cached[i], python_list[i], i)
+
+            # Delete the values
             del redis_list[i]
             del python_list[i]
             del redis_cached[i]
@@ -50,33 +62,33 @@ class ListTest(RedisTestCase):
             self.assertEqual(list(redis_list), python_list, i)
             self.assertEqual(list(redis_cached), python_list, i)
 
-    def test_delitem_slice(self):
+        for L in (redis_list, redis_cached, python_list):
+            self.assertRaises(IndexError, L.__getitem__, 4)
+            self.assertRaises(IndexError, L.__getitem__, -5)
+
+    def test_get_del_slice(self):
         data = (0, 1, 2, 3, 4, 5)
         for slice_args in [
-            # Delete everything
             (None, None, None),
             (0, None, None),
+            (0, 0, None),
             (0, 5, None),
             (0, 6, None),
-            # Delete from the left
             (None, 1, None),
             (0, 2, None),
             (0, -3, None),
             (0, 4, None),
             (0, -1, None),
             (0, 6, None),
-            # Delete to the right
             (1, None, None),
             (2, 6, None),
             (3, 6, None),
             (-2, None, None),
             (-1, None, None),
-            # Delete in the mdidle
             (1, -1, None),
             (2, -2, None),
             (3, -3, None),
             (-5, 5, None),
-            # Delete with a step
             (None, None, -1),
             (None, None, 1),
             (None, None, 2),
@@ -85,16 +97,143 @@ class ListTest(RedisTestCase):
             (5, 1, -1),
             (5, 1, -2),
         ]:
+            slice_obj = slice(*slice_args)
+
             redis_list = self.create_list(data)
             redis_cached = self.create_list(data, writeback=True)
             python_list = list(data)
 
-            del redis_list[slice(*slice_args)]
-            del python_list[slice(*slice_args)]
-            del redis_cached[slice(*slice_args)]
+            self.assertEqual(redis_list[slice_obj], python_list[slice_obj])
+            self.assertEqual(redis_cached[slice_obj], python_list[slice_obj])
+
+            del redis_list[slice_obj]
+            del redis_cached[slice_obj]
+            del python_list[slice_obj]
 
             self.assertEqual(list(redis_list), python_list, slice_args)
             self.assertEqual(list(redis_cached), python_list, slice_args)
+
+    def test_iter(self):
+        data = ('zero', 'one', 'two', 'three')
+        redis_list_iter = iter(self.create_list(data))
+        redis_cached_iter = iter(self.create_list(data, writeback=True))
+        python_iter = iter(list(data))
+        for v in data:
+            self.assertEqual(next(redis_list_iter), v)
+            self.assertEqual(next(redis_cached_iter), v)
+            self.assertEqual(next(python_iter), v)
+
+    def test_len(self):
+        for data, expected in [(tuple(), 0), ((0,), 1), ((0, 1,), 2)]:
+            redis_list = self.create_list(data)
+            redis_cached = self.create_list(data, writeback=True)
+            python_list = list(data)
+
+            self.assertEqual(len(redis_list), expected)
+            self.assertEqual(len(redis_cached), expected)
+            self.assertEqual(len(python_list), expected)
+
+    def test_reversed(self):
+        data = ('zero', 'one', 'two', 'three')
+        redis_list = self.create_list(data)
+        redis_cached = self.create_list(data, writeback=True)
+        python_list = list(data)
+
+        for L in (redis_list, redis_cached, python_list):
+            self.assertEqual(
+                list(reversed(redis_list)), list(reversed(python_list))
+            )
+            self.assertEqual(
+                list(reversed(redis_cached)), list(reversed(python_list))
+            )
+
+    def test_set_slice(self):
+        data = ('a', 'b', 'c', 'd', 'e', 'f')
+        for init, kwargs in (
+            (self.create_list, {}),
+            (self.create_list, {'writeback': True}),
+            (list, {}),
+        ):
+            L = init(data, **kwargs)
+            L[:1] = ['A', 'B']
+            self.assertEqual(list(L), ['A', 'B', 'b', 'c', 'd', 'e', 'f'])
+
+            L[2:-2] = ['C', 'D']
+            self.assertEqual(list(L), ['A', 'B', 'C', 'D', 'e', 'f'])
+
+            L[4:100] = ['E', 'F', 'G', 'H']
+            self.assertEqual(list(L), ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H'])
+
+            L[::2] = ['x', 'x', 'x', 'x']
+            self.assertEqual(list(L), ['x', 'B', 'x', 'D', 'x', 'F', 'x', 'H'])
+
+            L[6:1:-2] = ['y', 'y', 'y']
+            self.assertEqual(list(L), ['x', 'B', 'y', 'D', 'y', 'F', 'y', 'H'])
+
+            # Sequence length doesn't match
+            with self.assertRaises(ValueError):
+                L[6:1:-2] = ['y', 'y', 'y', 'y']
+
+            # Zero step
+            with self.assertRaises(ValueError):
+                L[::0] = []
+
+    def test_append(self):
+        for init, kwargs in (
+            (self.create_list, {}),
+            (self.create_list, {'writeback': True}),
+            (list, {}),
+        ):
+            L = init(**kwargs)
+            L.append('zero')
+            L.append('one')
+            L.append('two')
+
+            self.assertEqual(list(L), ['zero', 'one', 'two'])
+
+    def test_clear(self):
+        data = ('zero', 'one', 'two', 'three')
+        redis_list = self.create_list(data)
+        redis_cached = self.create_list(data, writeback=True)
+
+        # Python 2.x lists don't have a clear method
+        for L in (redis_list, redis_cached):
+            L[0] = 'Zero'
+            L.clear()
+            self.assertEqual(list(L), [])
+
+            with self.assertRaises(IndexError):
+                L[0]
+
+    def test_copy(self):
+        data = ('zero', 'one', 'two', 'three')
+
+        redis_list = self.create_list(data)
+        redis_list[0] = 'Zero'
+        new_list = redis_list.copy(redis=redis_list.redis)
+        self.assertEqual(list(new_list), list(redis_list))
+        self.assertTrue(new_list.redis is redis_list.redis)
+        self.assertFalse(new_list.writeback)
+
+        redis_cached = self.create_list(data, writeback=True)
+        redis_cached[0] = 'ZERO'
+        new_cached = redis_cached.copy()
+        self.assertEqual(list(new_cached), list(redis_cached))
+        self.assertTrue(new_cached.redis is redis_cached.redis)
+        self.assertTrue(new_cached.writeback)
+
+    def test_count(self):
+        data = ('a', 'b', 'b', 'c', 'c', 'c', None)
+        redis_list = self.create_list(data)
+        redis_cached = self.create_list(data, writeback=True)
+        python_list = list(data)
+
+        for L in (redis_list, redis_cached, python_list):
+            self.assertEqual(L.count('a'), 1)
+            self.assertEqual(L.count('b'), 2)
+            self.assertEqual(L.count('c'), 3)
+            self.assertEqual(L.count(None), 1)
+            self.assertEqual(L.count('A'), 0)
 
     def test_concat(self):
         for init in (self.create_list, list):
@@ -106,20 +245,6 @@ class ListTest(RedisTestCase):
             self.assertEqual(list(L_1 * 2), [1, 2, 3, 1, 2, 3])
             self.assertEqual(list(L_1 * 0), [])
             self.assertEqual(list(L_1 * -1), [])
-
-    def test_set_get_overflow(self):
-        L = self.create_list([1, 2, 3])
-
-        with self.assertRaises(IndexError):
-            L[42]
-
-        with self.assertRaises(IndexError):
-            L[42] = 4
-
-        with self.assertRaises(IndexError):
-            L[42]
-
-        self.assertEqual(L[1], 2)
 
     def test_index_count(self):
         for init in (self.create_list, list):
@@ -263,11 +388,6 @@ class ListTest(RedisTestCase):
             self.assertEqual(list(L), [6, 5, 1])
             L.append(7)
             self.assertEqual(list(L), [6, 5, 1, 7])
-
-    def test_reversed(self):
-        for init in (self.create_list, list):
-            L = init([0, 1, 2, 3])
-            self.assertEqual(list(reversed(L)), [3, 2, 1, 0])
 
     def test_mutable(self):
         redis_cached = self.create_list(writeback=True)


### PR DESCRIPTION
Re: #55 and #56, this PR:
* Adds support for the to-be-implemented features in `List`
* Changes slicing and addition to return Python `list`s instead of Redis-backed `List`s.
* Reduces number of race conditions for list operations
* Increases test coverage for `lists.py` significantly

This is for the 0.3.0 release (see #59). I'll probably squash the commits here together before merging.