### PR TITLE
Set changes

### DIFF
--- a/redis_collections/base.py
+++ b/redis_collections/base.py
@@ -6,7 +6,10 @@ base
 from __future__ import division, print_function, unicode_literals
 
 import abc
+from decimal import Decimal
+from fractions import Fraction
 import uuid
+
 try:
     import cPickle as pickle
 except ImportError:
@@ -15,6 +18,8 @@ import functools
 
 import redis
 import six
+
+NUMERIC_TYPES = six.integer_types + (float, Decimal, Fraction, complex)
 
 
 def same_types(fn):

--- a/redis_collections/dicts.py
+++ b/redis_collections/dicts.py
@@ -85,15 +85,16 @@ class Dict(RedisCollection, collections.MutableMapping):
 
         return key_hash, D
 
-    def __len__(self):
+    def __len__(self, pipe=None):
         """Return the number of items in the dictionary.
 
         .. note::
             Due to implementation on Redis side, this method is inefficient.
             The time taken is varies with the number of keys in stored.
         """
+        pipe = pipe or self.redis
         ret = 0
-        for D in six.itervalues(self.redis.hgetall(self.key)):
+        for D in six.itervalues(pipe.hgetall(self.key)):
             ret += len(self._unpickle(D))
 
         return ret

--- a/redis_collections/lists.py
+++ b/redis_collections/lists.py
@@ -296,9 +296,10 @@ class List(RedisCollection, collections.MutableSequence):
         """
         return (self.cache.get(i, v) for i, v in enumerate(self._data(pipe)))
 
-    def __len__(self):
+    def __len__(self, pipe=None):
         """Return the length of this collection."""
-        return self.redis.llen(self.key)
+        pipe = pipe or self.redis
+        return pipe.llen(self.key)
 
     def __reversed__(self):
         """

--- a/redis_collections/sets.py
+++ b/redis_collections/sets.py
@@ -70,7 +70,10 @@ class Set(RedisCollection, collections.MutableSet):
         # it on the way back out
         data = pickle.loads(string) if string else None
         if isinstance(data, six.binary_type):
-            data = data.decode('utf-8')
+            try:
+                data = data.decode('utf-8')
+            except UnicodeDecodeError:
+                pass
 
         return data
 

--- a/redis_collections/sets.py
+++ b/redis_collections/sets.py
@@ -1,297 +1,21 @@
 # -*- coding: utf-8 -*-
-"""
-sets
-~~~~
-
-Collections based on set interface.
-"""
 from __future__ import division, print_function, unicode_literals
 
-import abc
-import itertools
 import collections
+from functools import reduce
+import operator
 
-import six
-
-from .base import RedisCollection, same_types
-
-
-@six.add_metaclass(abc.ABCMeta)
-class SetOperation(object):
-    """Helper class for implementing standard set operations."""
-
-    def __init__(self, s, update=False, flipped=False, return_cls=None):
-        """
-        :param s: :class:`collections.Set` instance.
-        :param update: If :obj:`True`, operation is considered to be *update*.
-                       That means it affects directly the *s* object and
-                       returns the original object itself.
-         :param flipped: Specifies whether the operation is in reversed mode,
-                         where *s* is the right operand and *other* given to
-                         :func:`__call__` is the left one. With this option
-                         *update* must be :obj:`False` and only one other
-                         operand is accepted in :func:`__call__`.
-        :param return_cls: Class object specifying the type to be used for
-                            result of the operation. If *update* or *flipped*
-                            are :obj:`True`, this argument is ignored.
-        """
-        assert not (update and flipped)
-
-        self.s = s
-        self.update = update
-        self.flipped = flipped
-        self.return_cls = None if (update or flipped) else return_cls
-
-    def _are_set_instances(self, *others):
-        """Helper method deciding whether given *others* are instances
-        of :class:`Set` (sub)class.
-
-        :param others: Any objects.
-        :rtype: boolean
-        """
-        test = lambda other: isinstance(other, Set)
-        if len(others) == 1:
-            return test(others[0])
-        return all(map(test, others))
-
-    def _to_set(self, c, pipe=None):
-        if isinstance(c, RedisCollection):
-            return set(c._data(pipe=pipe))
-        return set(c)
-
-    def _op(self, key, return_cls, others):
-        """:func:`op` wrapper. Takes care of proper transaction
-        handling and result instantiation.
-        """
-        if self.flipped:
-            assert len(others) == 1
-            left = others[0]
-            right = [self.s]
-        else:
-            left = self.s
-            right = others
-
-        def trans(pipe):
-            # retrieve
-            data = self._to_set(left, pipe=pipe)
-            other_sets = [self._to_set(o, pipe=pipe) for o in right]
-
-            # operation
-            elements = self.op(data, other_sets)
-            pipe.multi()
-
-            # store within the transaction
-            return self.s._create_new(elements, key=key, cls=return_cls,
-                                      pipe=pipe)
-        return self.s._transaction(trans, key)
-
-    @abc.abstractmethod
-    def op(self, s, other_sets):
-        """Implementation of the operation on standard :class:`set`.
-
-        :param s: Data of the original collection as set (first operand).
-        :type s: :class:`set`
-        :param other_sets: Data of all the other collections participating
-                           in this operation as sets (other operands).
-        :type other_keys: iterable of :class:`frozenset` instances
-        :rtype: resulting iterable
-        """
-        pass
-
-    def _redisop(self, key, return_cls, other_keys):
-        """:func:`redisop` wrapper. Takes care of proper transaction
-        handling and result instantiation.
-        """
-        if self.flipped:
-            assert len(other_keys) == 1
-            left = other_keys[0]
-            right = [self.s.key]
-        else:
-            left = self.s.key
-            right = other_keys
-
-        def trans(pipe):
-            # operation
-            elements = self.redisop(pipe, left, right)
-            pipe.multi()
-
-            # store within the transaction
-            return self.s._create_new(elements, key=key, cls=return_cls,
-                                      pipe=pipe)
-        return self.s._transaction(trans, key, *other_keys)
-
-    @abc.abstractmethod
-    def redisop(self, pipe, key, other_keys):
-        """Implementation of the operation in Redis. Results
-        are returned to Python.
-
-        :param pipe: Redis transaction pipe.
-        :type pipe: :class:`redis.client.StrictPipeline`
-        :param key: Redis key from the original collection (first operand).
-        :type key: string
-        :param other_keys: Redis keys of all the other collections
-                           participating in this operation (other operands).
-        :type other_keys: iterable of strings
-        :rtype: resulting iterable
-        """
-        pass
-
-    def _redisopstore(self, key, return_cls, other_keys):
-        """:func:`redisopstore` wrapper. Takes care of proper transaction
-        handling and result instantiation.
-        """
-        if self.flipped:
-            assert len(other_keys) == 1
-            left = other_keys[0]
-            right = [self.s.key]
-        else:
-            left = self.s.key
-            right = other_keys
-
-        def trans(pipe):
-            # operation & possible store (in self.redisopstore)
-            new = self.s._create_new(key=key, cls=return_cls)
-            self.redisopstore(pipe, new.key, left, right)
-            return new
-        return self.s._transaction(trans, key, *other_keys)
-
-    @abc.abstractmethod
-    def redisopstore(self, pipe, new_key, key, other_keys):
-        """Implementation of the operation in Redis. Results
-        are stored to another key within Redis.
-
-        :param pipe: Redis transaction pipe.
-        :type pipe: :class:`redis.client.StrictPipeline`
-        :param new_key: Redis key of the new collection (destination).
-        :type new_key: string
-        :param key: Redis key from the original collection (first operand).
-        :type key: string
-        :param other_keys: Redis keys of all the other collections
-                           participating in this operation (other operands).
-        :type other_keys: iterable of strings
-        :rtype: :obj:`None`
-        """
-        pass
-
-    def __call__(self, *others):
-        """Operation trigger.
-
-        :param others: Iterable of one or more iterables, which are part
-                       of this operation.
-        """
-        if self.flipped:
-            # should return type of the left operand
-            assert len(others) == 1
-            return_cls = others[0].__class__
-        elif self.update:
-            # should return the original set
-            return_cls = self.s.__class__
-        else:
-            # should return type of the left operand or type
-            # specified in self.return_cls
-            return_cls = self.return_cls or Set
-
-        new_key = self.s.key if self.update else None
-
-        if self._are_set_instances(*others):
-            # all others are of Set type
-            other_keys = [other.key for other in others]
-
-            if issubclass(return_cls, self.s.__class__):
-                # operation can be performed in Redis completely
-                return self._redisopstore(new_key, return_cls, other_keys)
-            else:
-                # operation can be performed in Redis and returned to Python
-                return self._redisop(new_key, return_cls, other_keys)
-
-        # else do it in Python completely,
-        # simulating the same operation on standard set
-        return self._op(new_key, return_cls, others)
-
-
-class SetDifference(SetOperation):
-
-    def op(self, s, other_sets):
-        if self.update:
-            s.difference_update(*other_sets)
-            return s
-        return s.difference(*other_sets)
-
-    def redisop(self, pipe, key, other_keys):
-        return pipe.sdiff(key, *other_keys)
-
-    def redisopstore(self, pipe, new_key, key, other_keys):
-        pipe.multi()
-        pipe.sdiffstore(new_key, key, *other_keys)
-
-
-class SetIntersection(SetOperation):
-
-    def op(self, s, other_sets):
-        if self.update:
-            s.intersection_update(*other_sets)
-            return s
-        return s.intersection(*other_sets)
-
-    def redisop(self, pipe, key, other_keys):
-        return pipe.sinter(key, *other_keys)
-
-    def redisopstore(self, pipe, new_key, key, other_keys):
-        pipe.multi()
-        pipe.sinterstore(new_key, key, *other_keys)
-
-
-class SetUnion(SetOperation):
-
-    def op(self, s, other_sets):
-        if self.update:
-            s.update(*other_sets)
-            return s
-        return s.union(*other_sets)
-
-    def redisop(self, pipe, key, other_keys):
-        return pipe.sunion(key, *other_keys)
-
-    def redisopstore(self, pipe, new_key, key, other_keys):
-        pipe.multi()
-        pipe.sunionstore(new_key, key, *other_keys)
-
-
-class SetSymmetricDifference(SetOperation):
-
-    def op(self, s, other_sets):
-        if self.update:
-            s.symmetric_difference_update(*other_sets)
-            return s
-        return s.symmetric_difference(*other_sets)
-
-    def _simulate_redisop(self, pipe, key, other_key):
-        diff1 = pipe.sdiff(key, other_key)
-        diff2 = pipe.sdiff(other_key, key)
-        return diff1 | diff2  # return still pickled
-
-    def redisop(self, pipe, key, other_keys):
-        other_key = other_keys[0]  # sym. diff. supports only one operand
-        elements = self._simulate_redisop(pipe, key, other_key)
-        return [self.s._unpickle(x) for x in elements]
-
-    def redisopstore(self, pipe, new_key, key, other_keys):
-        other_key = other_keys[0]  # sym. diff. supports only one operand
-        elements = self._simulate_redisop(pipe, key, other_key)  # pickled
-        pipe.multi()
-        pipe.delete(new_key)
-        pipe.sadd(new_key, *elements)  # store pickled elements
+from .base import RedisCollection
 
 
 class Set(RedisCollection, collections.MutableSet):
-    """Mutable **set** collection aiming to have the same API as the standard
+    """
+    Mutable **set** collection aiming to have the same API as the standard
     set type. See `set
     <http://docs.python.org/2/library/stdtypes.html#set>`_ for
     further details. The Redis implementation is based on the
     `set <http://redis.io/commands#set>`_ type.
     """
-
-    _same_types = (collections.Set,)
 
     def __init__(self, *args, **kwargs):
         """
@@ -312,62 +36,101 @@ class Set(RedisCollection, collections.MutableSet):
             make your own implementation by subclassing and overriding
             internal method :func:`_create_key`.
         """
+        data = args[0] if args else kwargs.pop('data', None)
         super(Set, self).__init__(*args, **kwargs)
 
-    def __len__(self):
-        """Return cardinality of the set."""
-        return self.redis.scard(self.key)
+        if data:
+            self.update(data)
 
     def _data(self, pipe=None):
-        redis = pipe if pipe is not None else self.redis
-        return (self._unpickle(v) for v in redis.smembers(self.key))
+        pipe = pipe or self.redis
+        return (self._unpickle(x) for x in pipe.smembers(self.key))
+
+    def _repr_data(self, data):
+        return repr(set(data))
+
+    def __contains__(self, value, pipe=None):
+        """Test for membership of *value* in the set."""
+        pipe = pipe or self.redis
+        return bool(pipe.sismember(self.key, self._pickle(value)))
 
     def __iter__(self, pipe=None):
         """Return an iterator over elements of the set."""
+        pipe = pipe or self.redis
         return self._data(pipe)
 
-    def __contains__(self, elem):
-        """Test for membership of *elem* in the set."""
-        return self.redis.sismember(self.key, self._pickle(elem))
+    def __len__(self, pipe=None):
+        """Return cardinality of the set."""
+        pipe = pipe or self.redis
+        return pipe.scard(self.key)
 
-    def add(self, elem):
-        """Add element *elem* to the set. Returns :obj:`False` if
-        *elem* was already present in the set.
+    def add(self, value):
+        """Add element *value* to the set."""
+        # Raise TypeError if value is not hashable
+        hash(value)
 
+        self.redis.sadd(self.key, self._pickle(value))
+
+    def copy(self, key=None):
+        other = self.__class__(redis=self.redis, key=key)
+        other.update(self)
+
+        return other
+
+    def clear(self):
+        """Remove all elements from the set."""
+        self.redis.delete(self.key)
+
+    def discard(self, value):
+        """Remove element *value* from the set if it is present."""
+        # Raise TypeError if value is not hashable
+        hash(value)
+
+        self.redis.srem(self.key, self._pickle(value))
+
+    def isdisjoint(self, other):
+        """
+        Return ``True`` if the set has no elements in common with *other*.
+        Sets are disjoint if and only if their intersection is the empty set.
+
+        :param other: Any kind of iterable.
         :rtype: boolean
-
-        .. warning::
-            Original :func:`add` in :class:`set` returns no value.
         """
-        return bool(self.redis.sadd(self.key, self._pickle(elem)))
+        def isdisjoint_trans_pure(pipe):
+            return not pipe.sinter(self.key, other.key)
 
-    def discard(self, elem):
-        """Remove element *elem* from the set if it is present."""
-        self.redis.srem(self.key, self._pickle(elem))
+        def isdisjoint_trans_mixed(pipe):
+            self_values = set(self.__iter__(pipe))
+            if use_redis:
+                other_values = set(other.__iter__(pipe))
+            else:
+                other_values = set(other)
 
-    def remove(self, elem):
-        """Remove element *elem* from the set. Raises :exc:`KeyError` if elem
-        is not contained in the set.
-        """
-        removed_count = self.redis.srem(self.key, self._pickle(elem))
-        if not removed_count:
-            raise KeyError(elem)
+            return self_values.isdisjoint(other_values)
+
+        if isinstance(other, Set):
+            return self._transaction(isdisjoint_trans_pure, other.key)
+        if isinstance(other, RedisCollection):
+            use_redis = True
+            return self._transaction(isdisjoint_trans_mixed, other.key)
+
+        use_redis = False
+        return self._transaction(isdisjoint_trans_mixed)
 
     def pop(self):
-        """Remove and return an arbitrary element from the set.
+        """
+        Remove and return an arbitrary element from the set.
         Raises :exc:`KeyError` if the set is empty.
         """
-        with self.redis.pipeline() as pipe:
-            pipe.scard(self.key)
-            pipe.spop(self.key)
-            size, elem = pipe.execute()
-
-        if not size:
+        result = self.redis.spop(self.key)
+        if result is None:
             raise KeyError
-        return self._unpickle(elem)
+
+        return self._unpickle(result)
 
     def random_sample(self, k=1):
-        """Return a *k* length list of unique elements chosen from the set.
+        """
+        Return a *k* length list of unique elements chosen from the set.
         Elements are not removed. Similar to :func:`random.sample` function
         from standard library.
 
@@ -376,164 +139,226 @@ class Set(RedisCollection, collections.MutableSet):
 
         .. note::
             Argument *k* is supported only for Redis of version 2.6 and higher.
+            This method is not available on from the Python :class:`set`.
         """
-        if k < 1:
+        if k == 0:
             return []
+
         if k == 1:
-            elements = [self.redis.srandmember(self.key)]
+            results = [self.redis.srandmember(self.key)]
         else:
-            elements = self.redis.srandmember(self.key, k)
-        return [self._unpickle(x) for x in elements]
+            results = self.redis.srandmember(self.key, k)
 
-    def difference(self, *others, **kwargs):
-        """Return a new set with elements in the set that are
-        not in the *others*.
+        return [self._unpickle(x) for x in results]
 
-        :param others: Iterables, each one as a single positional argument.
-        :param return_cls: Keyword argument, type of result, defaults to
-                            the same type as collection (:class:`Set`,
-                            if not inherited).
-        :rtype: :class:`Set` or collection of type specified in
-                *return_cls* argument
-
-        .. note::
-            If all *others* are :class:`Set` instances, operation
-            is performed completely in Redis. If *return_cls* is provided,
-            operation is still performed in Redis, but results are sent
-            back to Python and returned with corresponding type. All other
-            combinations are performed in Python and results are sent
-            to Redis. See examples::
-
-                s1 = Set([1, 2])
-                s2 = Set([2, 3])
-                s3 = set([2, 3])  # built-in set
-
-                # Redis (whole operation)
-                s1.difference(s2, s2, s2)  # = Set
-
-                # Python (operation) → Redis (new key with Set)
-                s1.difference(s3)  # = Set
-
-                # Python (operation) → Redis (new key with Set)
-                s1.difference(s2, s3, s2)  # = Set
-
-                # Redis (operation) → Python (type conversion)
-                s1.difference(s2, return_cls=set)  # = set
-
-                # Redis (operation) → Python (type conversion)
-                s1.difference(s2, return_cls=list)  # = list
-
-                # Redis (operation) → Python → Redis (new key with List)
-                s1.difference(s2, return_cls=List)  # = List
+    def remove(self, value):
         """
-        return_cls = kwargs.get('return_cls', type(self))
-        op = SetDifference(self, return_cls=return_cls)
-        return op(*others)
-
-    @same_types
-    def __sub__(self, other):
-        """Return a new set with elements in the set that are
-        not in the *other*.
-
-        :param other: Set object (instance of :class:`collections.Set`
-                      ABC, so built-in sets and frozensets are also accepted),
-                      otherwise :exc:`TypeError` is raised.
-        :rtype: type of the first operand
-
-        .. note::
-            If *other* is instance of :class:`Set`, operation
-            is performed completely in Redis. Otherwise it's performed
-            in Python and results are sent to Redis.
+        Remove element *value* from the set. Raises :exc:`KeyError` if it
+        is not contained in the set.
         """
-        return self.difference(other)
+        # Raise TypeError if value is not hashable
+        hash(value)
 
-    @same_types
-    def __rsub__(self, other):
-        op = SetDifference(self, flipped=True)
-        return op(other)
+        result = self.redis.srem(self.key, self._pickle(value))
+        if not result:
+            raise KeyError(value)
 
-    def difference_update(self, *others):
-        """Update the set, removing elements found in *others*.
+    # Comparison and set operation helpers
 
-        :param others: Iterables, each one as a single positional argument.
-        :rtype: None
+    def _ge_helper(self, other, op, check_type=False):
+        if check_type and not isinstance(other, collections.Set):
+            raise TypeError
 
-        .. note::
-            If all *others* are :class:`Set` instances, operation
-            is performed completely in Redis. Otherwise it's performed
-            in Python and results are sent to Redis. See examples::
+        def ge_trans_pure(pipe):
+            if not op(self.__len__(pipe), other.__len__(pipe)):
+                return False
 
-                s1 = Set([1, 2])
-                s2 = Set([2, 3])
-                s3 = set([2, 3])  # built-in set
+            return not pipe.sdiff(other.key, self.key)
 
-                # Redis (whole operation)
-                s1.difference_update(s2, s2)  # = None
+        def ge_trans_mixed(pipe):
+            len_other = other.__len__(pipe) if use_redis else len(other)
+            if not op(self.__len__(pipe), len_other):
+                return False
 
-                # Python (operation) → Redis (update)
-                s1.difference(s3)  # = None
+            values = set(other.__iter__(pipe)) if use_redis else set(other)
+            return all(self.__contains__(v, pipe=pipe) for v in values)
 
-                # Python (operation) → Redis (update)
-                s1.difference(s2, s3, s2)  # = None
-        """
-        op = SetDifference(self, update=True)
-        op(*others)
+        if isinstance(other, Set):
+            return self._transaction(ge_trans_pure, other.key)
+        if isinstance(other, RedisCollection):
+            use_redis = True
+            return self._transaction(ge_trans_mixed, other.key)
 
-    @same_types
-    def __isub__(self, other):
-        """Update the set, removing elements found in *other*.
+        use_redis = False
+        return self._transaction(ge_trans_mixed)
 
-        :param other: Set object (instance of :class:`collections.Set`
-                      ABC, so built-in sets and frozensets are also accepted),
-                      otherwise :exc:`TypeError` is raised.
-        :rtype: None
+    def _le_helper(self, other, op, check_type=False):
+        if check_type and not isinstance(other, collections.Set):
+            raise TypeError
 
-        .. note::
-            If *other* is instance of :class:`Set`, operation
-            is performed completely in Redis. Otherwise it's performed
-            in Python and results are sent to Redis.
-        """
-        op = SetDifference(self, update=True)
-        return op(other)
+        def le_trans_pure(pipe):
+            if not op(self.__len__(pipe), other.__len__(pipe)):
+                return False
 
-    def intersection(self, *others, **kwargs):
-        """Return a new set with elements common to the set and all *others*.
+            return not pipe.sdiff(self.key, other.key)
 
-        :param others: Iterables, each one as a single positional argument.
-        :param return_cls: Keyword argument, type of result, defaults to
-                            the same type as collection (:class:`Set`,
-                            if not inherited).
-        :rtype: :class:`Set` or collection of type specified in
-                *return_cls* argument
+        def le_trans_mixed(pipe):
+            len_other = other.__len__(pipe) if use_redis else len(other)
+            if not op(self.__len__(pipe), len_other):
+                return False
 
-        .. note::
-            The same behavior as at :func:`difference` applies.
-        """
-        return_cls = kwargs.get('return_cls', type(self))
-        op = SetIntersection(self, return_cls=return_cls)
-        return op(*others)
+            values = set(other.__iter__(pipe)) if use_redis else set(other)
+            return all(v in values for v in self.__iter__(pipe))
 
-    @same_types
+        if isinstance(other, Set):
+            return self._transaction(le_trans_pure, other.key)
+        if isinstance(other, RedisCollection):
+            use_redis = True
+            return self._transaction(le_trans_mixed, other.key)
+
+        use_redis = False
+        return self._transaction(le_trans_mixed)
+
+    def _op_update_helper(
+        self, others, op, redis_op, update=False, check_type=False
+    ):
+        if check_type:
+            if not all(isinstance(x, collections.Set) for x in others):
+                raise TypeError
+
+        def op_update_trans_pure(pipe):
+            method = getattr(pipe, redis_op)
+            if not update:
+                result = method(self.key, *other_keys)
+                return {self._unpickle(x) for x in result}
+
+            temp_key = self._create_key()
+            pipe.multi()
+            method(temp_key, self.key, *other_keys)
+            pipe.rename(temp_key, self.key)
+
+        def op_update_trans_mixed(pipe):
+            self_values = set(self.__iter__(pipe))
+            other_values = []
+            for other in others:
+                if isinstance(other, RedisCollection):
+                    other_values.append(set(other.__iter__(pipe)))
+                else:
+                    other_values.append(set(other))
+
+            if not update:
+                return reduce(op, other_values, self_values)
+
+            new_values = reduce(op, other_values, self_values)
+            pipe.multi()
+            pipe.delete(self.key)
+            for v in new_values:
+                pipe.sadd(self.key, self._pickle(v))
+
+        other_keys = []
+        all_redis_sets = True
+        for other in others:
+            if isinstance(other, Set):
+                other_keys.append(other.key)
+            elif isinstance(other, RedisCollection):
+                other_keys.append(other.key)
+                all_redis_sets = False
+            else:
+                all_redis_sets = False
+
+        if all_redis_sets:
+            return self._transaction(op_update_trans_pure, *other_keys)
+
+        return self._transaction(op_update_trans_mixed, *other_keys)
+
+    def _rop_helper(self, other, op):
+        if not isinstance(other, collections.Set):
+            raise TypeError
+
+        return op(set(other), set(self.__iter__()))
+
+    def _xor_helper(self, other, update=False, check_type=False):
+        if check_type and not isinstance(other, collections.Set):
+            raise TypeError
+
+        def xor_trans_pure(pipe):
+            diff_1_key = self._create_key()
+            pipe.sdiffstore(diff_1_key, self.key, other.key)
+
+            diff_2_key = self._create_key()
+            pipe.sdiffstore(diff_2_key, other.key, self.key)
+
+            if update:
+                pipe.sunionstore(self.key, diff_1_key, diff_2_key)
+                ret = None
+            else:
+                ret = pipe.sunion(diff_1_key, diff_2_key)
+                ret = {self._unpickle(x) for x in ret}
+
+            pipe.delete(diff_1_key, diff_2_key)
+
+            return ret
+
+        def xor_trans_mixed(pipe):
+            self_values = set(self.__iter__(pipe))
+            if use_redis:
+                other_values = set(other.__iter__(pipe))
+            else:
+                other_values = set(other)
+
+            result = self_values ^ other_values
+
+            if update:
+                pipe.delete(self.key)
+                pipe.sadd(self.key, *(self._pickle(x) for x in result))
+                return None
+
+            return result
+
+        if isinstance(other, Set):
+            return self._transaction(xor_trans_pure, other.key)
+        elif isinstance(other, RedisCollection):
+            use_redis = True
+            return self._transaction(xor_trans_mixed, other.key)
+
+        use_redis = False
+        return self._transaction(xor_trans_mixed)
+
+    # Intersection
+
     def __and__(self, other):
-        """Return a new set with elements common to the set and the *other*.
+        return self._op_update_helper(
+            (other,), operator.and_, 'sinter', check_type=True
+        )
 
-        :param other: Set object (instance of :class:`collections.Set`
-                      ABC, so built-in sets and frozensets are also accepted),
-                      otherwise :exc:`TypeError` is raised.
-        :rtype: type of the first operand
+    def __rand__(self, other):
+        return self._rop_helper(other, operator.and_)
+
+    def __iand__(self, other):
+        self._op_update_helper(
+            (other,),
+            operator.and_,
+            'sinterstore',
+            update=True,
+            check_type=True,
+        )
+        return self
+
+    def intersection(self, *others):
+        """
+        Return a new set with elements common to the set and all *others*.
+
+        :param others: Iterables, each one as a single positional argument.
+        :rtype: :class:`set`
 
         .. note::
-            The same behavior as at :func:`__sub__` applies.
+            The same behavior as at :func:`union` applies.
         """
-        return self.intersection(other)
-
-    @same_types
-    def __rand__(self, other):
-        op = SetIntersection(self, flipped=True)
-        return op(other)
+        return self._op_update_helper(tuple(others), operator.and_, 'sinter')
 
     def intersection_update(self, *others):
-        """Update the set, keeping only elements found in it and all *others*.
+        """
+        Update the set, keeping only elements found in it and all *others*.
 
         :param others: Iterables, each one as a single positional argument.
         :rtype: None
@@ -541,221 +366,165 @@ class Set(RedisCollection, collections.MutableSet):
         .. note::
             The same behavior as at :func:`difference_update` applies.
         """
-        op = SetIntersection(self, update=True)
-        op(*others)
+        return self._op_update_helper(
+            tuple(others), operator.and_, 'sinterstore', update=True
+        )
 
-    @same_types
-    def __iand__(self, other):
-        """Update the set, keeping only elements found in it and the *other*.
+    # Comparison
 
-        :param other: Set object (instance of :class:`collections.Set`
-                      ABC, so built-in sets and frozensets are also accepted),
-                      otherwise :exc:`TypeError` is raised.
-        :rtype: None
-
-        .. note::
-            The same behavior as at :func:`__isub__` applies.
-        """
-        op = SetIntersection(self, update=True)
-        return op(other)
-
-    def union(self, *others, **kwargs):
-        """Return a new set with elements from the set and all *others*.
-
-        :param others: Iterables, each one as a single positional argument.
-        :param return_cls: Keyword argument, type of result, defaults to
-                            the same type as collection (:class:`Set`,
-                            if not inherited).
-        :rtype: :class:`Set` or collection of type specified in
-                *return_cls* argument
-
-        .. note::
-            The same behavior as at :func:`difference` applies.
-        """
-        return_cls = kwargs.get('return_cls', type(self))
-        op = SetUnion(self, return_cls=return_cls)
-        return op(*others)
-
-    @same_types
-    def __or__(self, other):
-        """Return a new set with elements from the set and the *other*.
-
-        :param other: Set object (instance of :class:`collections.Set`
-                      ABC, so built-in sets and frozensets are also accepted),
-                      otherwise :exc:`TypeError` is raised.
-        :rtype: type of the first operand
-
-        .. note::
-            The same behavior as at :func:`__sub__` applies.
-        """
-        return self.union(other)
-
-    @same_types
-    def __ror__(self, other):
-        return self.union(other, return_cls=other.__class__)
-
-    def _update(self, data, others=None, pipe=None):
-        super(Set, self)._update(data, pipe)
-        redis = pipe if pipe is not None else self.redis
-
-        others = [data] + list(others or [])
-        elements = [
-            self._pickle(x) for x in frozenset(itertools.chain(*others))
-        ]
-
-        redis.sadd(self.key, *elements)
-
-    def update(self, *others):
-        """Update the set, adding elements from all *others*.
-
-        :param others: Iterables, each one as a single positional argument.
-        :rtype: None
-
-        .. note::
-            The same behavior as at :func:`difference_update` applies.
-        """
-        op = SetUnion(self, update=True)
-        op(*others)
-
-    @same_types
-    def __ior__(self, other):
-        """Update the set, adding elements from the *other*.
-
-        :param other: Set object (instance of :class:`collections.Set`
-                      ABC, so built-in sets and frozensets are also accepted),
-                      otherwise :exc:`TypeError` is raised.
-        :rtype: None
-
-        .. note::
-            The same behavior as at :func:`__isub__` applies.
-        """
-        op = SetUnion(self, update=True)
-        return op(other)
-
-    def symmetric_difference(self, other, **kwargs):
-        """Return a new set with elements in either the set or *other* but not
-        both.
-
-        :param others: Any kind of iterable.
-        :param return_cls: Keyword argument, type of result, defaults to
-                            the same type as collection (:class:`Set`,
-                            if not inherited).
-        :rtype: :class:`Set` or collection of type specified in
-                *return_cls* argument
-
-        .. note::
-            The same behavior as at :func:`difference` applies.
-        """
-        return_cls = kwargs.get('return_cls', type(self))
-        op = SetSymmetricDifference(self, return_cls=return_cls)
-        return op(other)
-
-    @same_types
-    def __xor__(self, other):
-        """Update the set, keeping only elements found in either set, but not
-        in both.
-
-        :param other: Set object (instance of :class:`collections.Set`
-                      ABC, so built-in sets and frozensets are also accepted),
-                      otherwise :exc:`TypeError` is raised.
-        :rtype: type of the first operand
-
-        .. note::
-            The same behavior as at :func:`__sub__` applies.
-        """
-        return self.symmetric_difference(other)
-
-    @same_types
-    def __rxor__(self, other):
-        return self.symmetric_difference(other, return_cls=other.__class__)
-
-    def symmetric_difference_update(self, other):
-        """Update the set, keeping only elements found in either set, but not
-        in both.
-
-        :param others: Any kind of iterable.
-        :rtype: None
-
-        .. note::
-            A bit different behavior takes place in comparing
-            with the one described at :func:`difference_update`. Operation
-            is **always performed in Redis**, regardless the types given.
-            If *others* are instances of :class:`Set`, the performance
-            should be better as no transfer of data is necessary at all.
-        """
-        op = SetSymmetricDifference(self, update=True)
-        op(other)
-
-    @same_types
-    def __ixor__(self, other):
-        """Update the set, keeping only elements found in either set, but not
-        in both.
-
-        :param other: Set object (instance of :class:`collections.Set`
-                      ABC, so built-in sets and frozensets are also accepted),
-                      otherwise :exc:`TypeError` is raised.
-        :rtype: None
-
-        .. note::
-            The same behavior as at :func:`__isub__` applies.
-        """
-        op = SetSymmetricDifference(self, update=True)
-        return op(other)
-
-    def __eq__(self, other):
-        if not isinstance(other, collections.Set):
-            return NotImplemented
-        if isinstance(other, Set):
-            with self.redis.pipeline() as pipe:
-                pipe.smembers(self.key)
-                pipe.smembers(other.key)
-                members1, members2 = pipe.execute()
-            return members1 == members2
-        return frozenset(self) == frozenset(other)
-
-    def __le__(self, other):
-        if not isinstance(other, collections.Set):
-            return NotImplemented
-        return self.issubset(other)
-
-    def __lt__(self, other):
-        if not isinstance(other, collections.Set):
-            return NotImplemented
-        if isinstance(other, Set):
-            with self.redis.pipeline() as pipe:
-                pipe.smembers(self.key)
-                pipe.sinter(self.key, other.key)
-                pipe.scard(other.key)
-                members, inters, other_size = pipe.execute()
-            return (members == inters and len(members) != other_size)
-        return frozenset(self) < frozenset(other)
-
-    def issubset(self, other):
-        """Test whether every element in the set is in other.
-
-        :param other: Any kind of iterable.
-        :rtype: boolean
-        """
-        if isinstance(other, Set):
-            with self.redis.pipeline() as pipe:
-                pipe.smembers(self.key)
-                pipe.sinter(self.key, other.key)
-                members, inters = pipe.execute()
-            return members == inters
-        return frozenset(self) <= frozenset(other)
+    def __ge__(self, other):
+        return self._ge_helper(other, operator.ge, check_type=True)
 
     def issuperset(self, other):
-        """Test whether every element in other is in the set.
+        """
+        Test whether every element in other is in the set.
 
         :param other: Any kind of iterable.
         :rtype: boolean
         """
-        if isinstance(other, collections.Set):
-            return other <= self
-        else:
-            return frozenset(other) <= self
+        return self._ge_helper(other, operator.ge)
 
-    def _repr_data(self, data):
-        list_repr = repr(list(data))
-        set_repr = '{' + list_repr[1:-1] + '}'
-        return set_repr
+    def __gt__(self, other):
+        return self._ge_helper(other, operator.gt, check_type=True)
+
+    def __eq__(self, other):
+        return self._le_helper(other, operator.eq, check_type=True)
+
+    def __le__(self, other):
+        return self._le_helper(other, operator.le, check_type=True)
+
+    def issubset(self, other):
+        """
+        Test whether every element in the set is in *other*.
+
+        :param other: Any kind of iterable.
+        :rtype: boolean
+        """
+        return self._le_helper(other, operator.le)
+
+    def __lt__(self, other):
+        return self._le_helper(other, operator.lt)
+
+    # Union
+
+    def __or__(self, other):
+        return self._op_update_helper(
+            (other,), operator.or_, 'sunion', check_type=True
+        )
+
+    def __ror__(self, other):
+        return self._rop_helper(other, operator.or_)
+
+    def __ior__(self, other):
+        self._op_update_helper(
+            (other,), operator.or_, 'sunionstore', update=True, check_type=True
+        )
+        return self
+
+    def union(self, *others):
+        """
+        Return a new set with elements from the set and all *others*.
+
+        :param others: Iterables, each one as a single positional argument.
+        :rtype: :class:`set`
+
+        .. note::
+            If all *others* are :class:`Set` instances, the operation
+            is performed completely in Redis. Otherwise, values are retrieved
+            from Redis and the operation is performed in Python.
+        """
+        return self._op_update_helper(tuple(others), operator.or_, 'sunion')
+
+    def update(self, *others):
+        """
+        Update the set, adding elements from all *others*.
+
+        :param others: Iterables, each one as a single positional argument.
+        :rtype: None
+
+        .. note::
+            If all *others* are :class:`Set` instances, the operation
+            is performed completely in Redis. Otherwise, values are retrieved
+            from Redis and the operation is performed in Python.
+        """
+        return self._op_update_helper(
+            tuple(others), operator.or_, 'sunionstore', update=True
+        )
+
+    # Difference
+
+    def __sub__(self, other):
+        return self._op_update_helper(
+            (other,), operator.sub, 'sdiff', check_type=True
+        )
+
+    def __rsub__(self, other):
+        return self._rop_helper(other, operator.sub)
+
+    def __isub__(self, other):
+        self._op_update_helper(
+            (other,), operator.sub, 'sdiffstore', update=True, check_type=True
+        )
+        return self
+
+    def difference(self, *others):
+        """
+        Return a new set with elements in the set that are not in the *others*.
+
+        :param others: Iterables, each one as a single positional argument.
+        :rtype: :class:`set`
+
+        .. note::
+            The same behavior as at :func:`union` applies.
+        """
+        return self._op_update_helper(tuple(others), operator.sub, 'sdiff')
+
+    def difference_update(self, *others):
+        """
+        Update the set, removing elements found in *others*.
+
+        :param others: Iterables, each one as a single positional argument.
+        :rtype: None
+
+        .. note::
+            The same behavior as at :func:`update` applies.
+        """
+        return self._op_update_helper(
+            tuple(others), operator.sub, 'sdiffstore', update=True
+        )
+
+    # Symmetric difference
+
+    def __xor__(self, other):
+        return self._xor_helper(other, check_type=True)
+
+    def __ixor__(self, other):
+        self._xor_helper(other, update=True, check_type=True)
+        return self
+
+    def symmetric_difference(self, other):
+        """
+        Return a new set with elements in either the set or *other* but not
+        both.
+
+        :param other: Any kind of iterable.
+        :rtype: :class:`set`
+
+        .. note::
+            The same behavior as at :func:`union` applies.
+        """
+        return self._xor_helper(other)
+
+    def symmetric_difference_update(self, other):
+        """
+        Update the set, keeping only elements found in either set, but not
+        in both.
+
+        :param other: Any kind of iterable.
+        :rtype: None
+
+        .. note::
+            The same behavior as at :func:`update` applies.
+        """
+        self._xor_helper(other, update=True)
+        return self

--- a/tests/test_sets.py
+++ b/tests/test_sets.py
@@ -368,9 +368,14 @@ class SetTest(RedisTestCase):
     def test_add_unicode(self):
         for init in (self.create_set, set):
             s = init()
-            elem = 'ěščřžýáíéůú\U0001F4A9'
-            s.add(elem)
-            self.assertEqual(sorted(s), [elem])
+
+            elem_1 = 'ěščřžýáíéůú\U0001F4A9'
+            s.add(elem_1)
+            self.assertEqual(s.pop(), elem_1)
+
+            elem_2 = b'\x81'
+            s.add(elem_2)
+            self.assertEqual(s.pop(), elem_2)
 
     def test_add_equal_hashes(self):
         redis_set = Set()

--- a/tests/test_sets.py
+++ b/tests/test_sets.py
@@ -3,10 +3,14 @@
 from __future__ import division, print_function, unicode_literals
 
 import unittest
+import sys
 
 from redis_collections import Set
 
 from .base import RedisTestCase
+
+
+PYTHON_VERSION = (sys.version_info[0], sys.version_info[1])
 
 
 class SetTest(RedisTestCase):
@@ -86,7 +90,8 @@ class SetTest(RedisTestCase):
             self.assertFalse(s_1 < s_4)
 
             self.assertTrue(s_1.issubset(s_5))
-            self.assertRaises(TypeError, lambda: s_1 <= s_5)
+            if PYTHON_VERSION >= (3, 4):
+                self.assertRaises(TypeError, lambda: s_1 <= s_5)
 
             self.assertRaises(TypeError, s_1.issubset, None)
 
@@ -116,7 +121,8 @@ class SetTest(RedisTestCase):
             self.assertFalse(s_1 > s_5)
 
             self.assertTrue(s_1.issuperset(s_6))
-            self.assertRaises(TypeError, lambda: s_1 >= s_6)
+            if PYTHON_VERSION >= (3, 4):
+                self.assertRaises(TypeError, lambda: s_1 >= s_6)
 
             self.assertRaises(TypeError, s_1.issuperset, None)
 

--- a/tests/test_sets.py
+++ b/tests/test_sets.py
@@ -37,16 +37,14 @@ class SetTest(RedisTestCase):
     def test_in(self):
         for init in (self.create_set, set):
             s = init([1, 2, 3, 3])
-            self.assertEqual(1 in s, True)
-            self.assertEqual(42 in s, False)
-            self.assertEqual(1 not in s, False)
-            self.assertEqual(42 not in s, True)
+            self.assertIn(1, s)
+            self.assertNotIn(4, s)
 
     def test_equal(self):
         for init in (self.create_set, set):
             s_1 = init([1, 2, 3, 3])
             s_2 = init([4, 5])
-            s_3 = init([4, 5])
+            s_3 = {4, 5}
             self.assertNotEqual(s_1, s_3)
             self.assertNotEqual(s_1, s_3)
             self.assertEqual(s_2, s_3)
@@ -56,90 +54,150 @@ class SetTest(RedisTestCase):
         for init in (self.create_set, set):
             s_1 = init([1, 2, 3, 3])
             s_2 = init([4, 5])
+            s_3 = {3, 4, 5}
+            s_4 = [4, 5]
+
             self.assertTrue(s_1.isdisjoint(s_2))
+            self.assertFalse(s_1.isdisjoint(s_3))
+            self.assertTrue(s_1.isdisjoint(s_4))
+            self.assertRaises(TypeError, s_1.isdisjoint, None)
 
-    def test_subset(self):
-        for init in (self.create_set, set):
-            s_1 = init([1, 2, 3, 3])
-            s_2 = init([4, 5])
-            self.assertFalse(s_2.issubset(s_1))
+    def test_eq_le_lt_issubset(self):
+        for init in (self.create_set, set,):
+            s_1 = init([1, 2])
+            s_2 = init([1, 2, 3, 4])
+            s_3 = {1, 2, 3, 4}
+            s_4 = {1, 2}
+            s_5 = [1, 2, 3, 4]
 
-            s_2 = init([3, 2])
-            self.assertTrue(s_2.issubset(s_1))
-            self.assertTrue(s_2 <= s_1)
-            self.assertTrue(s_2 < s_1)
+            self.assertTrue(s_1.issubset(s_2))
+            self.assertFalse(s_1 == s_2)
+            self.assertTrue(s_1 <= s_2)
+            self.assertTrue(s_1 < s_2)
 
-            s_2 = init([1, 2, 3, 3])
-            self.assertFalse(s_2 < s_1)
+            self.assertTrue(s_1.issubset(s_3))
+            self.assertFalse(s_1 == s_3)
+            self.assertTrue(s_1 <= s_3)
+            self.assertTrue(s_1 < s_3)
+
+            self.assertTrue(s_1.issubset(s_4))
+            self.assertTrue(s_1 == s_4)
+            self.assertTrue(s_1 <= s_4)
+            self.assertFalse(s_1 < s_4)
+
+            self.assertTrue(s_1.issubset(s_5))
+            self.assertRaises(TypeError, lambda: s_1 <= s_5)
+
+            self.assertRaises(TypeError, s_1.issubset, None)
 
     def test_superset(self):
         for init in (self.create_set, set):
-            s_1 = init([1, 2, 3, 3])
-            s_2 = init([4, 5])
-            self.assertFalse(s_2.issuperset(s_1))
+            s_1 = init([1, 2, 3, 4])
+            s_2 = init([1, 2])
+            s_3 = init([1, 2, 3, 4, 5])
+            s_4 = {1, 2}
+            s_5 = {1, 2, 3, 4}
+            s_6 = [1, 2]
 
-            s_2 = init([3, 2])
             self.assertTrue(s_1.issuperset(s_2))
             self.assertTrue(s_1 >= s_2)
             self.assertTrue(s_1 > s_2)
 
-            s_2 = init([1, 2, 3, 3])
-            self.assertFalse(s_1 > s_2)
+            self.assertFalse(s_1.issuperset(s_3))
+            self.assertFalse(s_1 >= s_3)
+            self.assertFalse(s_1 > s_3)
+
+            self.assertTrue(s_1.issuperset(s_4))
+            self.assertTrue(s_1 >= s_4)
+            self.assertTrue(s_1 > s_4)
+
+            self.assertTrue(s_1.issuperset(s_5))
+            self.assertTrue(s_1 >= s_5)
+            self.assertFalse(s_1 > s_5)
+
+            self.assertTrue(s_1.issuperset(s_6))
+            self.assertRaises(TypeError, lambda: s_1 >= s_6)
+
+            self.assertRaises(TypeError, s_1.issuperset, None)
 
     def test_union(self):
         for init in (self.create_set, set):
-            s_1 = init([1, 2, 3, 3])
-            s_2 = init([4, 5])
-            s_3 = set([6])
-            l = [6]
-            self.assertEqual(sorted(s_1 | s_2), [1, 2, 3, 4, 5])
-            self.assertEqual(sorted(s_1.union(s_2)), [1, 2, 3, 4, 5])
-            self.assertEqual(sorted(s_1 | s_2 | s_3), [1, 2, 3, 4, 5, 6])
-            self.assertEqual(sorted(s_1.union(s_2, s_3)), [1, 2, 3, 4, 5, 6])
-            self.assertRaises(TypeError, lambda: s_1 | s_2 | l)
-            self.assertEqual(sorted(s_1.union(s_2, l)), [1, 2, 3, 4, 5, 6])
+            s_1 = init([1, 2])
+            s_2 = init([2, 3, 4])
+            s_3 = {2, 3, 4}
+            s_4 = [2, 3, 4]
+
+            self.assertEqual(sorted(s_1.union(s_2)), [1, 2, 3, 4])
+            self.assertEqual(sorted(s_1 | s_2), [1, 2, 3, 4])
+            self.assertEqual(sorted(s_2 | s_1), [1, 2, 3, 4])
+
+            self.assertEqual(sorted(s_1.union(s_3)), [1, 2, 3, 4])
+            self.assertEqual(sorted(s_1 | s_3), [1, 2, 3, 4])
+            self.assertEqual(sorted(s_3 | s_1), [1, 2, 3, 4])
+
+            self.assertEqual(sorted(s_1.union(s_4)), [1, 2, 3, 4])
+            self.assertRaises(TypeError, lambda: s_1 | s_4)
+            self.assertRaises(TypeError, lambda: s_4 | s_1)
 
     def test_intersection(self):
         for init in (self.create_set, set):
-            s_1 = init([1, 2, 3, 3])
-            s_2 = init([3, 4, 5])
-            s_3 = set([6])
-            l = [6]
-            self.assertEqual(sorted(s_1 & s_2), [3])
-            self.assertEqual(sorted(s_1.intersection(s_2)), [3])
-            self.assertEqual(sorted(s_1 & s_2 & s_3), [])
-            self.assertEqual(sorted(s_1.intersection(s_2, s_3)), [])
-            self.assertRaises(TypeError, lambda: s_1 & s_2 & l)
-            self.assertEqual(sorted(s_1.intersection(s_2, l)), [])
-            self.assertEqual(sorted(s_3 & s_2), [])
+            s_1 = init([1, 2, 3])
+            s_2 = init([2, 3, 4])
+            s_3 = {2, 3, 4}
+            s_4 = [2, 3, 4]
+
+            self.assertEqual(sorted(s_1.intersection(s_2)), [2, 3])
+            self.assertEqual(sorted(s_1 & s_2), [2, 3])
+            self.assertEqual(sorted(s_2 & s_1), [2, 3])
+
+            self.assertEqual(sorted(s_1.intersection(s_3)), [2, 3])
+            self.assertEqual(sorted(s_1 & s_3), [2, 3])
+            self.assertEqual(sorted(s_3 & s_1), [2, 3])
+
+            self.assertEqual(sorted(s_1.intersection(s_4)), [2, 3])
+            self.assertRaises(TypeError, lambda: s_1 & s_4)
 
     def test_difference(self):
         for init in (self.create_set, set):
-            s_1 = init([1, 2, 3, 3])
-            s_2 = init([3, 4, 5])
-            s_3 = set([6])
-            l = [6]
-            self.assertEqual(sorted(s_1 - s_2), [1, 2])
+            s_1 = init([1, 2, 3, 4])
+            s_2 = init([3, 4])
+            s_3 = {3, 4}
+            s_4 = [3, 4]
+
             self.assertEqual(sorted(s_1.difference(s_2)), [1, 2])
-            self.assertEqual(sorted(s_1 - s_2 - s_3), [1, 2])
-            self.assertEqual(sorted(s_1.difference(s_2, s_3)), [1, 2])
-            self.assertRaises(TypeError, lambda: s_1 - s_2 - l)
-            self.assertEqual(sorted(s_1.difference(s_2, l)), [1, 2])
-            self.assertEqual(sorted(s_3 - s_1), [6])
+            self.assertEqual(sorted(s_1 - s_2), [1, 2])
+            self.assertEqual(sorted(s_2 - s_1), [])
+
+            self.assertEqual(sorted(s_1.difference(s_3)), [1, 2])
+            self.assertEqual(sorted(s_1 - s_3), [1, 2])
+            self.assertEqual(sorted(s_3 - s_1), [])
+
+            self.assertEqual(sorted(s_1.difference(s_4)), [1, 2])
+            self.assertRaises(TypeError, lambda: s_1 - s_4)
 
     def test_symmetric_difference(self):
         for init in (self.create_set, set):
-            s_1 = init([1, 2, 3, 3])
-            s_2 = init([3, 4, 5])
-            s_3 = set([6])
-            l = [6]
-            self.assertEqual(sorted(s_1 ^ s_2), [1, 2, 4, 5])
+            s_1 = init([1, 2, 3, 4])
+            s_2 = init([3, 4, 5, 6])
+            s_3 = {3, 4, 5, 6}
+            s_4 = [3, 4, 5, 6]
+
             self.assertEqual(
-                sorted(s_1.symmetric_difference(s_2)), [1, 2, 4, 5]
+                sorted(s_1.symmetric_difference(s_2)), [1, 2, 5, 6]
             )
-            self.assertEqual(sorted(s_1 ^ s_2 ^ s_3), [1, 2, 4, 5, 6])
-            self.assertRaises(TypeError, lambda: s_1 ^ s_2 ^ l)
-            self.assertEqual(sorted(s_3 ^ s_1 ^ s_2), [1, 2, 4, 5, 6])
+            self.assertEqual(sorted(s_1 ^ s_2), [1, 2, 5, 6])
+            self.assertEqual(sorted(s_2 ^ s_1), [1, 2, 5, 6])
+
+            self.assertEqual(
+                sorted(s_1.symmetric_difference(s_3)), [1, 2, 5, 6]
+            )
+            self.assertEqual(sorted(s_1 ^ s_3), [1, 2, 5, 6])
+            self.assertEqual(sorted(s_3 ^ s_1), [1, 2, 5, 6])
+
+            self.assertEqual(
+                sorted(s_1.symmetric_difference(s_4)), [1, 2, 5, 6]
+            )
+            self.assertRaises(TypeError, lambda: s_1 ^ s_4)
 
     def test_copy(self):
         for init in (self.create_set, set):
@@ -148,64 +206,125 @@ class SetTest(RedisTestCase):
             self.assertEqual(s_1.__class__, s_2.__class__)
             self.assertEqual(sorted(s_1), sorted(s_2))
 
-    def test_result_type(self):
-        for init in (self.create_set, set):
-            s_1 = init('ab')
-            s_2 = set('bc')
-            s_3 = s_1 | s_2
-            s4 = s_2 | s_1
-            self.assertEqual(s_3.__class__, s_1.__class__)
-            self.assertEqual(s4.__class__, s_2.__class__)
-
     def test_update(self):
         for init in (self.create_set, set):
-            s_1 = init('ab')
-            s_2 = frozenset('bc')
-            st = 'cd'
-            s_1 |= s_2
-            self.assertEqual(sorted(s_1), ['a', 'b', 'c'])
-            s_1.update(s_2, st)
-            self.assertEqual(sorted(s_1), ['a', 'b', 'c', 'd'])
+            s_1 = init([0, 1])
+            s_2 = init([1, 2])
+            s_3 = init([2, 3])
+            s_4 = {3, 4}
+            s_5 = {4, 5}
+            s_6 = [5, 6]
+            s_7 = [6, 7]
+
+            s_1.update(s_2)
+            self.assertEqual(sorted(s_1), list(range(3)))
+
+            s_1 |= s_3
+            self.assertEqual(sorted(s_1), list(range(4)))
+
+            s_1.update(s_4)
+            self.assertEqual(sorted(s_1), list(range(5)))
+
+            s_1 |= s_5
+            self.assertEqual(sorted(s_1), list(range(6)))
+
+            s_1.update(s_6)
+            self.assertEqual(sorted(s_1), list(range(7)))
+
+            with self.assertRaises(TypeError):
+                s_1 |= s_7
 
     def test_intersection_update(self):
         for init in (self.create_set, set):
-            s_1 = init('ab')
-            s_2 = frozenset('bc')
-            st = 'cd'
-            s_1 &= s_2
-            self.assertEqual(sorted(s_1), ['b'])
-            s_1.intersection_update(s_2, st)
-            self.assertEqual(sorted(s_1), [])
+            s_1 = init(range(8))
+            s_2 = init(range(7))
+            s_3 = init(range(6))
+            s_4 = set(range(5))
+            s_5 = set(range(4))
+            s_6 = list(range(3))
+            s_7 = list(range(2))
+
+            s_1.intersection_update(s_2)
+            self.assertEqual(sorted(s_1), list(range(7)))
+
+            s_1 &= s_3
+            self.assertEqual(sorted(s_1), list(range(6)))
+
+            s_1.intersection_update(s_4)
+            self.assertEqual(sorted(s_1), list(range(5)))
+
+            s_1 &= s_5
+            self.assertEqual(sorted(s_1), list(range(4)))
+
+            s_1.intersection_update(s_6)
+            self.assertEqual(sorted(s_1), list(range(3)))
+
+            with self.assertRaises(TypeError):
+                s_1 &= s_7
 
     def test_difference_update(self):
         for init in (self.create_set, set):
-            s_1 = init('ab')
-            s_2 = frozenset('bc')
-            s_3 = 'cd'
-            s_1 -= s_2
-            self.assertEqual(sorted(s_1), ['a'])
-            s_1.difference_update(s_2, s_3)
-            self.assertEqual(sorted(s_1), ['a'])
+            s_1 = init(range(8))
+            s_2 = init(range(2))
+            s_3 = init(range(3))
+            s_4 = set(range(4))
+            s_5 = set(range(5))
+            s_6 = list(range(6))
+            s_7 = list(range(7))
+
+            s_1.difference_update(s_2)
+            self.assertEqual(sorted(s_1), list(range(2, 8)))
+
+            s_1 -= s_3
+            self.assertEqual(sorted(s_1), list(range(3, 8)))
+
+            s_1.difference_update(s_4)
+            self.assertEqual(sorted(s_1), list(range(4, 8)))
+
+            s_1 -= s_5
+            self.assertEqual(sorted(s_1), list(range(5, 8)))
+
+            s_1.difference_update(s_6)
+            self.assertEqual(sorted(s_1), list(range(6, 8)))
+
+            with self.assertRaises(TypeError):
+                s_1 -= s_7
 
     def test_symmetric_difference_update(self):
         for init in (self.create_set, set):
             s_1 = init('ab')
-            s_2 = frozenset('bc')
-            s_3 = 'cd'
-            s_1 ^= s_2
-            self.assertEqual(sorted(s_1), ['a', 'c'])
-            s_1.symmetric_difference_update(s_3)
-            self.assertEqual(sorted(s_1), ['a', 'd'])
+            s_2 = init('bc')
+            s_3 = init('cd')
+            s_4 = set('de')
+            s_5 = set('ef')
+            s_6 = 'fg'
+            s_7 = 'gh'
+
+            s_1.symmetric_difference_update(s_2)
+            self.assertEqual(''.join(sorted(s_1)), 'ac')
+
+            s_1 ^= s_3
+            self.assertEqual(''.join(sorted(s_1)), 'ad')
+
+            s_1.symmetric_difference_update(s_4)
+            self.assertEqual(''.join(sorted(s_1)), 'ae')
+
+            s_1 ^= s_5
+            self.assertEqual(''.join(sorted(s_1)), 'af')
+
+            s_1.symmetric_difference_update(s_6)
+            self.assertEqual(''.join(sorted(s_1)), 'ag')
+
+            with self.assertRaises(TypeError):
+                s_1 ^= s_7
 
     def test_add(self):
         s = self.create_set('ab')
+        s.add('b')
         s.add('c')
         self.assertEqual(sorted(s), ['a', 'b', 'c'])
 
-        # Returning True or False after addition isn't something the native
-        # Python `set` does
-        self.assertFalse(s.add('c'))
-        self.assertTrue(s.add('d'))
+        self.assertRaises(TypeError, s.add, dict())
 
     def test_remove_discard(self):
         for init in (self.create_set, set):
@@ -226,13 +345,13 @@ class SetTest(RedisTestCase):
 
     def test_random_sample(self):
         s = self.create_set('a')
+        self.assertEqual(s.random_sample(0), [])
         self.assertEqual(s.random_sample(), ['a'])
 
         redis_version = self.redis.info()['redis_version']
         redis_version = [int(x) for x in redis_version.split('.')]
         major_ver, minor_ver, _ = redis_version
-
-        if major_ver >= 2 and minor_ver >= 6:
+        if (major_ver > 2) or (major_ver >= 2 and minor_ver >= 6):
             s = self.create_set('ab')
             self.assertEqual(sorted(s.random_sample(2)), ['a', 'b'])
 

--- a/tests/test_sets.py
+++ b/tests/test_sets.py
@@ -199,8 +199,9 @@ class SetTest(RedisTestCase):
             self.assertEqual(
                 sorted(s_1.symmetric_difference(s_3)), [1, 2, 5, 6]
             )
-            self.assertEqual(sorted(s_1 ^ s_3), [1, 2, 5, 6])
-            self.assertEqual(sorted(s_3 ^ s_1), [1, 2, 5, 6])
+            if PYTHON_VERSION >= (3, 4):
+                self.assertEqual(sorted(s_1 ^ s_3), [1, 2, 5, 6])
+                self.assertEqual(sorted(s_3 ^ s_1), [1, 2, 5, 6])
 
             self.assertEqual(
                 sorted(s_1.symmetric_difference(s_4)), [1, 2, 5, 6]


### PR DESCRIPTION
Re: #56 (return Python objects for non "update" methods) and #49 (things allowed in Redis-backed `Set`s that aren't allowed in Python `set`s), this PR makes significant changes to the `Set` class.

---

__Numeric key changes__: As [the issue](https://github.com/honzajavorek/redis-collections/issues/49) describes, previously there were surprises like this for using `Set`s with numeric keys: 

```python
... redis_set, python_set = Set(), set()
... for x in [1, 1.0, complex(1, 0), Fraction(1, 1), Decimal(1.0)]:
...     redis_set.add(x)
...     python_set.add(x)
>>> list(redis_set)
[Fraction(1, 1), 1.0, Decimal('1'), 1, (1+0j)]
>>> list(python_set)
[1]
```

This PR changes things such that equal numeric types will be serialized to the same values a la [Python's `hash` function](https://docs.python.org/3/library/stdtypes.html#hashing-of-numeric-types).

The downside is this: with a Python `set`, the first value you store determines what you get back out - if you store an integer and then an equal float, you get an integer back. If you store a float and then an equal integer, you get a float back.

```python
>>> s_1 = set()
... s_1.add(1.0)
... s_1.add(1)
... 
... s_2 = set()
... s_2.add(1)
... s_2.add(1.0)
>>> s_1, s_2
13: (set([1.0]), set([1]))
```

With a `Set` you will now always get back the integer - there's no way to store the type.

---

__basestring key changes (Python 2)__:  For Python 2 there was a similar issue with `unicode` and `str` objects - a `Set` with `b'a'` and `u'a'` would have two items, but a `set` would just have one.

This PR changes (only for Python 2) serialization and deserialization such that `unicode` objects are encoded before pickling and decoded after unpickling. 

As above, Python `set`s will give you back what you put in first; Redis-backed `Set`s will give you back  `unicode` if possible.

---

__Other changes__: I re-worked most of the binary operator and in-place operator methods to return Python `sets` as per #56. I moved most of the logic out of the mixin classes and into helper methods, with an eye toward avoiding race conditions.

I also learned much more about Python sets than I knew was out there - who knew that `set | list` fails, but `set.union(list)` succeeds?

---

This is for 0.3.0 - see #59. I will adopt the hashing changes for `Dict` next.