### PR TITLE
Version bump to 0.2.1

### DIFF
--- a/redis_collections/__init__.py
+++ b/redis_collections/__init__.py
@@ -2,7 +2,7 @@
 from __future__ import division, print_function, unicode_literals
 
 __title__ = 'redis-collections'
-__version__ = '0.2.0'
+__version__ = '0.2.1'
 __author__ = 'Honza Javorek'
 __license__ = 'ISC'
 __copyright__ = 'Copyright 2013-? Honza Javorek'


### PR DESCRIPTION
This PR bumps the version number such that the fix in #57 can be released to PyPI.