### PR TITLE
Don't assume all collections stored on same Redis server B/W Clean up base class

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -71,17 +71,21 @@ By default, collections use a new Redis connection with its default values, **wh
     >>> d = Dict(redis=r)
     >>> l = List(redis=r)  # using the same connection as Dict above
 
-There are several operations between collections resulting into creation of new instances of Redis Collections. These new instances
-always use the same Redis connection as the original object::
+A collection's ``copy`` method creates new instance that uses the same Redis connection as the original object::
 
-    >>> from redis import StrictRedis
-    >>> from redis_collections import List
-    >>> r = StrictRedis()
-    >>> l = List([1, 2], redis=r)
-    >>> l
+    >>> conn = StrictRedis()
+    >>> list_01 = List([1, 2], redis=conn)
+    >>> list_01
     <redis_collections.List at 196e407f8fc142728318a999ec821368 [1, 2]>
-    >>> l + [4, 5, 6]  # result is using the same connection
-    <redis_collections.List at 7790ef98639043c9abeacc80c2de0b93 [1, 2, 4, 5, 6]>
+    >>> list_02 = list_01.copy()  # result is using the same connection
+    <redis_collections.List at 7790ef98639043c9abeacc80c2de0b93 [1, 2]>
+
+Operations on two collections backed by different Redis servers will be performed in Python::
+
+    >>> list_1 = List((1, 2, 3), redis=StrictRedis(port=6379))
+    >>> list_2 = List((4, 5, 6), redis=StrictRedis(port=6380))
+    >>> list_1.extend(list_2)
+
 
 Synchronization
 ---------------

--- a/redis_collections/base.py
+++ b/redis_collections/base.py
@@ -191,6 +191,16 @@ class RedisCollection(object):
         self.redis.transaction(trans, self.key, *extra_keys)
         return results[0]
 
+    def __enter__(self):
+        self.writeback = True
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.sync()
+
+    def sync(self):
+        pass
+    
     def _repr_data(self, data):
         return repr(data)
 

--- a/redis_collections/base.py
+++ b/redis_collections/base.py
@@ -200,7 +200,7 @@ class RedisCollection(object):
 
     def sync(self):
         pass
-    
+
     def _repr_data(self, data):
         return repr(data)
 

--- a/redis_collections/base.py
+++ b/redis_collections/base.py
@@ -201,10 +201,10 @@ class RedisCollection(object):
     def sync(self):
         pass
 
-    def _repr_data(self, data):
-        return repr(data)
+    def _repr_data(self):
+        return None
 
     def __repr__(self):
         cls_name = self.__class__.__name__
-        data = self._repr_data(self._data())
+        data = self._repr_data()
         return '<redis_collections.%s at %s %s>' % (cls_name, self.key, data)

--- a/redis_collections/base.py
+++ b/redis_collections/base.py
@@ -145,18 +145,6 @@ class RedisCollection(object):
 
         return data
 
-    def _update(self, data, pipe=None):
-        """Helper for update operations.
-
-        :param data: Data for update in form of a classic, built-in collection.
-        :param pipe: Redis pipe in case update is performed as a part
-                     of transaction.
-        :type pipe: :class:`redis.client.StrictPipeline` or
-                    :class:`redis.client.StrictRedis`
-        """
-        assert not isinstance(data, RedisCollection), \
-            "Not atomic. Use '_data()' within a transaction first."
-
     def _clear(self, pipe=None):
         """Helper for clear operations.
 

--- a/redis_collections/base.py
+++ b/redis_collections/base.py
@@ -14,39 +14,11 @@ try:
     import cPickle as pickle
 except ImportError:
     import pickle as pickle  # NOQA
-import functools
 
 import redis
 import six
 
 NUMERIC_TYPES = six.integer_types + (float, Decimal, Fraction, complex)
-
-
-def same_types(fn):
-    """Decorator, helps to check whether operands are of
-    the same type as *self*. It is possible to extend
-    allowed types by defining ``_same_types`` class property
-    with tuple of allowed classes.
-    """
-    @functools.wraps(fn)
-    def wrapper(self, *args):
-        types = (self.__class__,) + self._same_types
-
-        # all args must be an instance of any of the types
-        allowed = all([
-            any([isinstance(arg, t) for t in types])
-            for arg in args
-        ])
-
-        if not allowed:
-            types_msg = ', '.join(types[:-1])
-            types_msg = ' or '.join([types_msg, types[-1]])
-            message = ('Only instances of %s are '
-                       'supported as operand types.') % types_msg
-            raise TypeError(message)
-
-        return fn(self, *args)
-    return wrapper
 
 
 @six.add_metaclass(abc.ABCMeta)
@@ -55,13 +27,11 @@ class RedisCollection(object):
     Redis collections.
     """
 
-    _same_types = ()
-
     not_impl_msg = ('Cannot be implemented efficiently or atomically '
                     'due to limitations in Redis command set.')
 
     @abc.abstractmethod
-    def __init__(self, data=None, redis=None, key=None):
+    def __init__(self, redis=None, key=None):
         """
         :param data: Initial data.
         :param redis: Redis client instance. If not provided, default Redis
@@ -85,78 +55,6 @@ class RedisCollection(object):
 
         #: Redis key of the collection.
         self.key = key or self._create_key()
-
-        # data initialization
-        if data is not None:
-            if isinstance(data, RedisCollection):
-                # wrap into transaction
-                def init_trans(pipe):
-                    d = data._data(pipe=pipe)  # retrieve
-                    pipe.multi()
-                    self._init_data(d, pipe=pipe)  # store
-                self._transaction(init_trans)
-            else:
-                self._init_data(data)
-
-    def _create_new(self, data=None, key=None, pipe=None, cls=None):
-        """Shorthand for creating instances of any collections. *cls*
-        specifies the type of collection to be created. If subclass of
-        :class:`RedisCollection` given, all settings from current ``self``
-        are propagated.
-
-        :param data: Initial data in form of a classic, built-in collection.
-        :param key: Redis key of the instance. Ignored if *cls* is not a
-                   :class:`RedisCollection` subclass.
-        :type key: string
-        :param pipe: Redis pipe in case creation is performed as a part
-                     of transaction. Ignored if *cls* is not a
-                     :class:`RedisCollection` subclass.
-        :type pipe: :class:`redis.client.StrictPipeline` or
-                    :class:`redis.client.StrictRedis`
-        :param cls: Type of the collection. Defaults to ``self.__class__``.
-        :type cls: Class object.
-        """
-        assert not isinstance(data, RedisCollection), \
-            "Not atomic. Use '_data()' within a transaction first."
-        cls = cls or self.__class__
-        if issubclass(cls, RedisCollection):
-            settings = {
-                'key': key,
-                'redis': self.redis,
-            }
-
-            if pipe is not None and data:
-                # here we cannot use cls(data, **settings), because
-                # that would not be atomic within the transaction
-                new = cls(**settings)
-                new._init_data(data, pipe=pipe)
-                return new
-            return cls(data, **settings)
-
-        return cls(data) if data else cls()
-
-    def _init_data(self, data, pipe=None):
-        """Data initialization helper.
-
-        :param data: Initial data in form of a classic, built-in collection.
-        :param pipe: Redis pipe in case creation is performed as a part
-                     of transaction.
-        :type pipe: :class:`redis.client.StrictPipeline` or
-                    :class:`redis.client.StrictRedis`
-        """
-        assert not isinstance(data, RedisCollection), \
-            "Not atomic. Use '_data()' within a transaction first."
-
-        # if not in pipe, make your own
-        p = pipe if pipe is not None else self.redis.pipeline()
-        if data is not None:
-            self._clear(pipe=p)
-            if data:
-                # non-empty data, populate collection
-                self._update(data, pipe=p)
-        if pipe is None:
-            # own pipe, execute it
-            p.execute()
 
     def _create_redis(self):
         """Creates default Redis connection.
@@ -188,7 +86,6 @@ class RedisCollection(object):
         :type pipe: :class:`redis.client.StrictPipeline` or
                     :class:`redis.client.StrictRedis`
         """
-        pass
 
     def _pickle(self, data):
         """Converts given data to string.
@@ -268,12 +165,8 @@ class RedisCollection(object):
         :type pipe: :class:`redis.client.StrictPipeline` or
                     :class:`redis.client.StrictRedis`
         """
-        redis = pipe if pipe is not None else self.redis
+        redis = pipe or self.redis
         redis.delete(self.key)
-
-    def clear(self):
-        """Completely cleares the collection's data."""
-        self._clear()
 
     def _transaction(self, fn, *extra_keys):
         """Helper simplifying code within watched transaction.
@@ -295,18 +188,6 @@ class RedisCollection(object):
 
         self.redis.transaction(trans, self.key, *extra_keys)
         return results[0]
-
-    def copy(self, key=None):
-        """Return a copy of the collection.
-
-        :param key: Key of the new collection. Defaults to auto-generated.
-        :type key: string
-        """
-        def copy_trans(pipe):
-            data = self._data(pipe=pipe)  # retrieve
-            pipe.multi()
-            return self._create_new(data, key=key, pipe=pipe)  # store
-        return self._transaction(copy_trans, key)
 
     def _repr_data(self, data):
         return repr(data)

--- a/redis_collections/base.py
+++ b/redis_collections/base.py
@@ -156,6 +156,20 @@ class RedisCollection(object):
         redis = pipe or self.redis
         redis.delete(self.key)
 
+    def _same_redis(self, other, cls=None):
+        cls = cls or self.__class__
+        if not isinstance(other, cls):
+            return False
+
+        self_kwargs = self.redis.connection_pool.connection_kwargs
+        other_kwargs = other.redis.connection_pool.connection_kwargs
+
+        return (
+            self_kwargs['host'] == other_kwargs['host'] and
+            self_kwargs['port'] == other_kwargs['port'] and
+            self_kwargs.get('db', 0) == other_kwargs.get('db', 0)
+        )
+
     def _transaction(self, fn, *extra_keys):
         """Helper simplifying code within watched transaction.
 

--- a/redis_collections/dicts.py
+++ b/redis_collections/dicts.py
@@ -76,7 +76,7 @@ class Dict(RedisCollection, collections.MutableMapping):
         """
         data = args[0] if args else kwargs.pop('data', None)
         writeback = kwargs.pop('writeback', False)
-        super(Dict, self).__init__(*args, **kwargs)
+        super(Dict, self).__init__(**kwargs)
 
         self.writeback = writeback
         self.cache = {}
@@ -330,9 +330,11 @@ class Dict(RedisCollection, collections.MutableMapping):
 
         return other
 
-    def clear(self):
-        self.redis.delete(self.key)
-        self.cache.clear()
+    def clear(self, pipe=None):
+        self._clear(pipe)
+
+        if self.writeback:
+            self.cache.clear()
 
     @classmethod
     def fromkeys(cls, seq, value=None, **kwargs):
@@ -380,8 +382,6 @@ class Counter(Dict):
         methods :func:`viewitems`, :func:`viewkeys`, and :func:`viewvalues`,
         which are available in Python 2.7's version.
     """
-
-    _same_types = (collections.Counter,)
 
     def __init__(self, *args, **kwargs):
         """Breakes the original :class:`Counter` API, because there is no

--- a/redis_collections/dicts.py
+++ b/redis_collections/dicts.py
@@ -355,8 +355,9 @@ class Dict(RedisCollection, collections.MutableMapping):
         values = ((item, value) for item in seq)
         return cls(values, **kwargs)
 
-    def _repr_data(self, data):
-        return repr(dict(data))
+    def _repr_data(self):
+        items = ('{}: {}'.format(repr(k), repr(v)) for k, v in self.items())
+        return '{{{}}}'.format(', '.join(items))
 
     def sync(self):
         self.writeback = False

--- a/redis_collections/dicts.py
+++ b/redis_collections/dicts.py
@@ -358,13 +358,6 @@ class Dict(RedisCollection, collections.MutableMapping):
     def _repr_data(self, data):
         return repr(dict(data))
 
-    def __enter__(self):
-        self.writeback = True
-        return self
-
-    def __exit__(self, exc_type, exc_value, traceback):
-        self.sync()
-
     def sync(self):
         self.writeback = False
         self._update_helper(self.cache)

--- a/redis_collections/dicts.py
+++ b/redis_collections/dicts.py
@@ -671,8 +671,8 @@ class DefaultDict(Dict):
         self[key] = value
         return value
 
-    def copy(self, **kwargs):
-        other = self.__class__(self.default_factory, **kwargs)
+    def copy(self, key=None):
+        other = self.__class__(self.default_factory, redis=self.redis, key=key)
         other.update(self)
 
         return other

--- a/redis_collections/lists.py
+++ b/redis_collections/lists.py
@@ -50,7 +50,7 @@ class List(RedisCollection, collections.MutableSequence):
         """
         data = args[0] if args else kwargs.pop('data', None)
         writeback = kwargs.pop('writeback', False)
-        super(List, self).__init__(*args, **kwargs)
+        super(List, self).__init__(**kwargs)
 
         self.__marker = uuid.uuid4().hex
         self.writeback = writeback
@@ -385,8 +385,7 @@ class List(RedisCollection, collections.MutableSequence):
 
     def clear(self, pipe=None):
         """Delete all values from this collection."""
-        pipe = pipe or self.redis
-        pipe.delete(self.key)
+        self._clear(pipe)
 
         if self.writeback:
             self.cache.clear()

--- a/redis_collections/lists.py
+++ b/redis_collections/lists.py
@@ -591,8 +591,9 @@ class List(RedisCollection, collections.MutableSequence):
         self._transaction(imul_trans)
         return self
 
-    def _repr_data(self, data):
-        return repr(list(data))
+    def _repr_data(self):
+        items = (repr(v) for v in self.__iter__())
+        return '[{}]'.format(', '.join(items))
 
     def _sync_helper(self, pipe):
         for i, v in six.iteritems(self.cache):

--- a/redis_collections/lists.py
+++ b/redis_collections/lists.py
@@ -594,13 +594,6 @@ class List(RedisCollection, collections.MutableSequence):
     def _repr_data(self, data):
         return repr(list(data))
 
-    def __enter__(self):
-        self.writeback = True
-        return self
-
-    def __exit__(self, exc_type, exc_value, traceback):
-        self.sync()
-
     def _sync_helper(self, pipe):
         for i, v in six.iteritems(self.cache):
             pipe.lset(self.key, i, self._pickle(v))

--- a/redis_collections/lists.py
+++ b/redis_collections/lists.py
@@ -390,13 +390,14 @@ class List(RedisCollection, collections.MutableSequence):
         if self.writeback:
             self.cache.clear()
 
-    def copy(self, redis=None, key=None):
+    def copy(self, key=None):
         """
         Return a new :obj:``List`` with the specified *key*. The new collection
         will have the same values as this collection.
         """
-        redis = redis or self.redis
-        other = self.__class__(redis=redis, key=key, writeback=self.writeback)
+        other = self.__class__(
+            redis=self.redis, key=key, writeback=self.writeback
+        )
         other.extend(self)
 
         return other

--- a/redis_collections/lists.py
+++ b/redis_collections/lists.py
@@ -425,7 +425,7 @@ class List(RedisCollection, collections.MutableSequence):
                 for i, v in enumerate(values, len_self - len(values)):
                     self.cache[i] = v
 
-        if isinstance(other, RedisCollection):
+        if self._same_redis(other, RedisCollection):
             use_redis = True
             self._transaction(extend_trans, other.key)
         else:

--- a/redis_collections/sets.py
+++ b/redis_collections/sets.py
@@ -120,9 +120,9 @@ class Set(RedisCollection, collections.MutableSet):
 
             return self_values.isdisjoint(other_values)
 
-        if isinstance(other, Set):
+        if self._same_redis(other):
             return self._transaction(isdisjoint_trans_pure, other.key)
-        if isinstance(other, RedisCollection):
+        if self._same_redis(other, RedisCollection):
             use_redis = True
             return self._transaction(isdisjoint_trans_mixed, other.key)
 
@@ -195,9 +195,9 @@ class Set(RedisCollection, collections.MutableSet):
             values = set(other.__iter__(pipe)) if use_redis else set(other)
             return all(self.__contains__(v, pipe=pipe) for v in values)
 
-        if isinstance(other, Set):
+        if self._same_redis(other):
             return self._transaction(ge_trans_pure, other.key)
-        if isinstance(other, RedisCollection):
+        if self._same_redis(other, RedisCollection):
             use_redis = True
             return self._transaction(ge_trans_mixed, other.key)
 
@@ -222,9 +222,9 @@ class Set(RedisCollection, collections.MutableSet):
             values = set(other.__iter__(pipe)) if use_redis else set(other)
             return all(v in values for v in self.__iter__(pipe))
 
-        if isinstance(other, Set):
+        if self._same_redis(other):
             return self._transaction(le_trans_pure, other.key)
-        if isinstance(other, RedisCollection):
+        if self._same_redis(other, RedisCollection):
             use_redis = True
             return self._transaction(le_trans_mixed, other.key)
 
@@ -272,9 +272,9 @@ class Set(RedisCollection, collections.MutableSet):
         other_keys = []
         all_redis_sets = True
         for other in others:
-            if isinstance(other, Set):
+            if self._same_redis(other):
                 other_keys.append(other.key)
-            elif isinstance(other, RedisCollection):
+            elif self._same_redis(other, RedisCollection):
                 other_keys.append(other.key)
                 all_redis_sets = False
             else:
@@ -329,9 +329,9 @@ class Set(RedisCollection, collections.MutableSet):
 
             return result
 
-        if isinstance(other, Set):
+        if self._same_redis(other):
             return self._transaction(xor_trans_pure, other.key)
-        elif isinstance(other, RedisCollection):
+        elif self._same_redis(other, RedisCollection):
             use_redis = True
             return self._transaction(xor_trans_mixed, other.key)
 

--- a/redis_collections/sets.py
+++ b/redis_collections/sets.py
@@ -45,7 +45,7 @@ class Set(RedisCollection, collections.MutableSet):
             internal method :func:`_create_key`.
         """
         data = args[0] if args else kwargs.pop('data', None)
-        super(Set, self).__init__(*args, **kwargs)
+        super(Set, self).__init__(**kwargs)
 
         if data:
             self.update(data)
@@ -89,9 +89,9 @@ class Set(RedisCollection, collections.MutableSet):
 
         return other
 
-    def clear(self):
+    def clear(self, pipe=None):
         """Remove all elements from the set."""
-        self.redis.delete(self.key)
+        self._clear(pipe)
 
     def discard(self, value):
         """Remove element *value* from the set if it is present."""

--- a/redis_collections/sets.py
+++ b/redis_collections/sets.py
@@ -54,8 +54,9 @@ class Set(RedisCollection, collections.MutableSet):
         pipe = pipe or self.redis
         return (self._unpickle(x) for x in pipe.smembers(self.key))
 
-    def _repr_data(self, data):
-        return repr(set(data))
+    def _repr_data(self):
+        items = (repr(v) for v in self.__iter__())
+        return '{{{}}}'.format(', '.join(items))
 
     # Magic methods
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import division, print_function, unicode_literals
 
+import io
 import os
 import re
 import subprocess
@@ -25,7 +26,7 @@ base_path = os.path.dirname(__file__)
 
 # version
 meta_file = os.path.join(base_path, 'redis_collections/__init__.py')
-meta_file_contents = open(meta_file).read()
+meta_file_contents = io.open(meta_file, encoding='utf-8').read()
 meta = dict(re.findall(r'__([^_]+)__ = \'([^\']*)\'', meta_file_contents))
 
 
@@ -41,11 +42,11 @@ setup(
     name=meta['title'],
     version=meta['version'],
     description='Set of basic Python collections backed by Redis.',
-    long_description=open('README.rst', encoding='utf-8').read(),
+    long_description=io.open('README.rst', encoding='utf-8').read(),
     author=meta['author'],
     author_email='mail@honzajavorek.cz',
     url='https://github.com/honzajavorek/redis-collections',
-    license=open('LICENSE').read(),
+    license=io.open('LICENSE', encoding='utf-8').read(),
     packages=find_packages(exclude=['tests']),
     include_package_data=True,
     install_requires=['redis>=2.7.2', 'six>=1.10.0'],

--- a/tests/test_dicts.py
+++ b/tests/test_dicts.py
@@ -370,9 +370,9 @@ class DictTest(RedisTestCase):
     def test_repr(self):
         redis_dict = self.create_dict(writeback=True)
         redis_dict[0] = {}
-        redis_dict[0]['key'] = 'value'
+        redis_dict[0][1] = 2
 
-        self.assertIn("{0: {'key': 'value'}}", repr(redis_dict))
+        self.assertIn("{0: {1: 2}}", repr(redis_dict))
 
 
 class CounterTest(RedisTestCase):

--- a/tests/test_dicts.py
+++ b/tests/test_dicts.py
@@ -367,6 +367,13 @@ class DictTest(RedisTestCase):
         # Closing the context manager syncs to Redis
         self.assertEqual(D._data()['key'], [1, 2])
 
+    def test_repr(self):
+        redis_dict = self.create_dict(writeback=True)
+        redis_dict[0] = {}
+        redis_dict[0]['key'] = 'value'
+
+        self.assertIn("{0: {'key': 'value'}}", repr(redis_dict))
+
 
 class CounterTest(RedisTestCase):
 
@@ -691,6 +698,7 @@ class DefaultDictTest(RedisTestCase):
         self.assertEqual(
             redis_ddict.default_factory, redis_copy.default_factory
         )
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_lists.py
+++ b/tests/test_lists.py
@@ -523,5 +523,12 @@ class ListTest(RedisTestCase):
 
         self.assertEqual(list(redis_cached._data())[0], {'one': 2})
 
+    def test_repr(self):
+        redis_list = self.create_list(writeback=True)
+        redis_list.append({})
+        redis_list[0]['key'] = 'value'
+
+        self.assertIn("[{'key': 'value'}]", repr(redis_list))
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_lists.py
+++ b/tests/test_lists.py
@@ -212,7 +212,7 @@ class ListTest(RedisTestCase):
 
         redis_list = self.create_list(data)
         redis_list[0] = 'Zero'
-        new_list = redis_list.copy(redis=redis_list.redis)
+        new_list = redis_list.copy(key=redis_list.key)
         self.assertEqual(list(new_list), list(redis_list))
         self.assertTrue(new_list.redis is redis_list.redis)
         self.assertFalse(new_list.writeback)

--- a/tests/test_lists.py
+++ b/tests/test_lists.py
@@ -526,9 +526,9 @@ class ListTest(RedisTestCase):
     def test_repr(self):
         redis_list = self.create_list(writeback=True)
         redis_list.append({})
-        redis_list[0]['key'] = 'value'
+        redis_list[0][1] = 2
 
-        self.assertIn("[{'key': 'value'}]", repr(redis_list))
+        self.assertIn("[{1: 2}]", repr(redis_list))
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_sets.py
+++ b/tests/test_sets.py
@@ -414,6 +414,13 @@ class SetTest(RedisTestCase):
             s.clear()
             self.assertEqual(sorted(s), [])
 
+    def test_repr(self):
+        redis_set = self.create_set()
+        redis_set.add(1)
+        redis_set.add(1.0)
+
+        self.assertIn("{1}", repr(redis_set))
+
 
 class _Set(Set):
     pass


### PR DESCRIPTION
Re: #17, this PR fixes a problem with using multiple Redis servers (or DBs).

---

Before this would raise an exception:
```python
>>> list_1 = List((1, 2, 3), redis=StrictRedis(db=0))
>>> list_2 = List((4, 5, 6), redis=StrictRedis(db=1))
>>> list_1.extend(list_2)
```

Now it gives the right result:
```
>>> list_1
<redis_collections.List at f55b1b39d6444ec6930bfd51eec93329 [1, 2, 3, 4, 5, 6]>
```

When dealing with two `RedisCollection` objects, the `_same_redis` method checks the (1) host, (2) port, (3) database number to determine whether operations can be done in Redis. If one of those doesn't match then the collections fall back to doing the operations in Python. This supersedes the `same_types` function.

---

This PR also cleans up some now-unused methods in the base class (e.g.  `_create_new` and `_update`;  these were not quite flexible enough for the `writeback` changes from earlier) and re-works `__repr__` (and adds tests for it).

---

This is for 0.3.0 - see #59.