### PR TITLE
Deque

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -47,4 +47,6 @@ New features in 0.3.x
 
 - `Cross-process Dict access <https://github.com/honzajavorek/redis-collections/issues/58>`_ should now work for Python 3.3 and later again.
 
+- `Deque <https://github.com/honzajavorek/redis-collections/issues/6>`_ was added.
+
 See the `Github milestone <https://github.com/honzajavorek/redis-collections/milestone/1>`_ for more details.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,7 +4,7 @@
 Redis Collections
 =================
 
-`redis-collections` is a library that provides several Python collection types backed by Redis.
+`redis-collections` is a library that provides several Python collection types (such as ``Dict``, ``List``, ``Set``, and more) backed by Redis.
 This exposes Redis functionality with a Pythonic interface, and provides a simple way to store Python objects across sessions and processes.
 
 This library builds on `Redis <http://redis.io/>`_, the excellent key-value store, and on `redis-py <https://github.com/andymccurdy/redis-py>`_, the well-designed Python interface for it.
@@ -189,6 +189,10 @@ Redis Collections are composed of only several classes. All items listed below a
 .. automodule:: redis_collections.lists
 
 .. autoclass:: List
+    :members:
+    :special-members:
+
+.. autoclass:: Deque
     :members:
     :special-members:
 

--- a/redis_collections/__init__.py
+++ b/redis_collections/__init__.py
@@ -10,7 +10,15 @@ __copyright__ = 'Copyright 2013-? Honza Javorek'
 
 from .base import RedisCollection  # NOQA
 from .dicts import DefaultDict, Dict, Counter  # NOQA
-from .lists import List  # NOQA
+from .lists import Deque, List  # NOQA
 from .sets import Set  # NOQA
 
-__all__ = ['RedisCollection', 'Set', 'List', 'DefaultDict', 'Dict', 'Counter']
+__all__ = [
+    'Counter',
+    'DefaultDict',
+    'Deque',
+    'Dict',
+    'List',
+    'RedisCollection',
+    'Set',
+]

--- a/redis_collections/lists.py
+++ b/redis_collections/lists.py
@@ -640,9 +640,33 @@ class List(RedisCollection, collections.MutableSequence):
 
 
 class Deque(List):
+    """A Redis-backed version of Python's :class:`collections.deque`.
+    See Python's `deque documentation
+    <https://docs.python.org/3/library/collections.html#collections.deque>`_
+    for more details. The Redis implementation is based on the `list type
+    <http://redis.io/commands#list>`_.
+    """
+
     python_cls = collections.deque
 
     def __init__(self, *args, **kwargs):
+        """
+        :param data: Initial data.
+        :type data: iterable
+        :param maxlen: Maximum size.
+        :type maxlen: int
+        :param redis: Redis client instance. If not provided, default Redis
+                      connection is used.
+        :type redis: :class:`redis.StrictRedis`
+        :param key: Redis key of the collection. Collections with the same key
+                    point to the same data. If not provided, default random
+                    string is generated.
+        :type key: str
+        :param writeback: If ``True`` keep a local cache of changes for storing
+                          modifications to mutable values. Changes will be
+                          written to Redis after calling the ``sync`` method.
+        :type key: bool
+        """
         if len(args) > 2:
             msg = '{} takes at most 2 positional arguments ({} given)'
             raise TypeError(msg.format(self.__class__, len(args)))

--- a/redis_collections/lists.py
+++ b/redis_collections/lists.py
@@ -666,6 +666,10 @@ class Deque(List):
                           modifications to mutable values. Changes will be
                           written to Redis after calling the ``sync`` method.
         :type key: bool
+
+        .. warning::
+            The ``maxlen`` of the collection can't be enforced when multiple
+            processes are accessing its Redis collection.
         """
         if len(args) > 2:
             msg = '{} takes at most 2 positional arguments ({} given)'

--- a/redis_collections/lists.py
+++ b/redis_collections/lists.py
@@ -846,7 +846,7 @@ class Deque(List):
     # Operator methods
 
     def __add__(self, other):
-        if not isinstance(other, (Deque, collections.deque)):
+        if not isinstance(other, (self.__class__, self.python_cls)):
             raise TypeError
 
         if self._same_redis(other, RedisCollection):
@@ -857,23 +857,19 @@ class Deque(List):
         return self._add_helper(other, maxlen=self.maxlen)
 
     def __radd__(self, other):
-        if not isinstance(other, (Deque, collections.deque)):
+        if not isinstance(other, (self.__class__, self.python_cls)):
             raise TypeError
-
-        if self._same_redis(other, RedisCollection):
-            return self._add_helper(
-                other, use_redis=True, swap_args=True, maxlen=other.maxlen
-            )
 
         return self._add_helper(
             other, swap_args=True, maxlen=other.maxlen
         )
 
     def __iadd__(self, other):
-        if not isinstance(other, (Deque, collections.deque)):
+        if not isinstance(other, (self.__class__, self.python_cls)):
             raise TypeError
 
-        return self.extend(other)
+        self.extend(other)
+        return self
 
     def __mul__(self, times):
         if not isinstance(times, six.integer_types):

--- a/tests/test_lists.py
+++ b/tests/test_lists.py
@@ -2,11 +2,16 @@
 # -*- coding: utf-8 -*-
 from __future__ import division, print_function, unicode_literals
 
+import collections
+import sys
 import unittest
 
-from redis_collections import List
+from redis_collections import List, Deque
 
 from .base import RedisTestCase
+
+
+PYTHON_VERSION = (sys.version_info[0], sys.version_info[1])
 
 
 class ListTest(RedisTestCase):
@@ -360,7 +365,9 @@ class ListTest(RedisTestCase):
 
         for L in (redis_list, redis_cached, python_list):
             self.assertEqual(L + ['x', 'y'], [0, 1, 2, 3, 'x', 'y'])
-            self.assertEqual(['x', 'y'] + L, ['x', 'y', 0, 1, 2, 3])
+            self.assertEqual(L + ['x', 'y'], [0, 1, 2, 3, 'x', 'y'])
+            self.assertEqual(L + redis_list, [0, 1, 2, 3, 0, 1, 2, 3])
+            self.assertEqual(redis_list + L, [0, 1, 2, 3, 0, 1, 2, 3])
 
     def test_mul(self):
         data = (0, 1)
@@ -530,6 +537,167 @@ class ListTest(RedisTestCase):
         redis_list[0][1] = 2
 
         self.assertIn("[{1: 2}]", repr(redis_list))
+
+
+class DequeTest(RedisTestCase):
+
+    def create_deque(self, *args, **kwargs):
+        kwargs['redis'] = self.redis
+        return Deque(*args, **kwargs)
+
+    def test_init(self):
+        for init in (self.create_deque, collections.deque):
+            self.assertRaises(TypeError, init, 'abcd', 4, None)
+
+    def test_delitem(self):
+        data = 'abcd'
+        for init in (self.create_deque, collections.deque):
+            Q = init(data)
+
+            with self.assertRaises(TypeError):
+                Q[1:-1]
+
+            del Q[1]
+            self.assertEqual(list(Q), ['a', 'c', 'd'])
+
+    def test_getitem(self):
+        data = 'abcd'
+        for init in (self.create_deque, collections.deque):
+            Q = init(data)
+
+            self.assertRaises(TypeError, lambda: Q[1:-1])
+            self.assertEqual(Q[0], 'a')
+            self.assertEqual(Q[1], 'b')
+            self.assertEqual(Q[-2], 'c')
+            self.assertEqual(Q[-1], 'd')
+
+    def test_setitem(self):
+        data = 'abcd'
+        for init in (self.create_deque, collections.deque):
+            Q = init(data)
+
+            with self.assertRaises(TypeError):
+                Q[1:-1] = ['x', 'y']
+
+            Q[0] = 'w'
+            Q[1] = 'x'
+            Q[-2] = 'y'
+            Q[-1] = 'z'
+            self.assertEqual(list(Q), ['w', 'x', 'y', 'z'])
+
+    def test_append(self):
+        data = 'abcd'
+        for init in (self.create_deque, collections.deque):
+            Q = init(data)
+            Q_limit = init(data, 5)
+
+            Q.append('e')
+            self.assertEqual(list(Q), ['a', 'b', 'c', 'd', 'e'])
+
+            Q_limit.append('e')
+            self.assertEqual(list(Q_limit), ['a', 'b', 'c', 'd', 'e'])
+
+            Q.append('f')
+            self.assertEqual(list(Q), ['a', 'b', 'c', 'd', 'e', 'f'])
+
+            Q_limit.append('f')
+            self.assertEqual(list(Q_limit), ['b', 'c', 'd', 'e', 'f'])
+
+    def test_appendleft(self):
+        data = 'abcd'
+        for init in (self.create_deque, collections.deque):
+            Q = init(data)
+            Q_limit = init(data, 5)
+
+            Q.appendleft('e')
+            self.assertEqual(list(Q), ['e', 'a', 'b', 'c', 'd'])
+
+            Q_limit.appendleft('e')
+            self.assertEqual(list(Q_limit), ['e', 'a', 'b', 'c', 'd'])
+
+            Q.appendleft('f')
+            self.assertEqual(list(Q), ['f', 'e', 'a', 'b', 'c', 'd'])
+
+            Q_limit.appendleft('f')
+            self.assertEqual(list(Q_limit), ['f', 'e', 'a', 'b', 'c'])
+
+    def test_copy(self):
+        data = ['a', 'b', 'c', 'd']
+        Q = self.create_deque(data, 5, writeback=True)
+        Q_copy = Q.copy()
+        self.assertEqual(list(Q), list(Q_copy))
+        self.assertEqual(Q.maxlen, Q_copy.maxlen)
+        self.assertTrue(Q.redis is Q_copy.redis)
+        self.assertTrue(Q_copy.writeback)
+
+    def test_extend(self):
+        data = 'abcd'
+        for init in (self.create_deque, collections.deque):
+            Q = init(data)
+            Q_limit = init(data, 5)
+
+            Q.extend(['e', 'f'])
+            self.assertEqual(list(Q), ['a', 'b', 'c', 'd', 'e', 'f'])
+
+            Q_limit.extend(['e', 'f'])
+            self.assertEqual(list(Q_limit), ['b', 'c', 'd', 'e', 'f'])
+
+            Q.extend(Q_limit)
+            self.assertEqual(list(Q), list('abcdefbcdef'))
+
+    def test_extendleft(self):
+        data = 'abcd'
+        for init in (self.create_deque, collections.deque):
+            Q = init(data)
+            Q_limit = init(data, 5)
+
+            Q.extendleft(['e', 'f'])
+            self.assertEqual(list(Q), list('feabcd'))
+
+            Q_limit.extendleft(['e', 'f'])
+            self.assertEqual(list(Q_limit), list('feabc'))
+
+            Q.extendleft(Q_limit)
+            self.assertEqual(list(Q), list('cbaeffeabcd'))
+
+    @unittest.skip(PYTHON_VERSION >= (3, 5))
+    def test_insert(self):
+        data = 'abcd'
+        for init in (self.create_deque, collections.deque):
+            Q = init(data)
+            Q_limit = init(data, 5)
+
+            Q.insert(1, 'x')
+            self.assertEqual(list(Q), list('axbcd'))
+
+            Q_limit.insert(1, 'x')
+            self.assertEqual(list(Q_limit), list('axbcd'))
+
+            Q.insert(0, 'y')
+            self.assertEqual(list(Q), list('yaxbcd'))
+
+            self.assertRaises(IndexError, Q_limit.insert, 1, 'y')
+
+            Q.insert(-1, 'z')
+            self.assertEqual(list(Q), list('yaxbczd'))
+
+    def test_pop_popleft(self):
+        data = 'abcd'
+        for init in (self.create_deque, collections.deque):
+            Q = init(data)
+
+            self.assertEqual(Q.pop(), 'd')
+            self.assertEqual(list(Q), list('abc'))
+
+            self.assertEqual(Q.popleft(), 'a')
+            self.assertEqual(list(Q), list('bc'))
+
+            self.assertEqual(Q.pop(), 'c')
+            self.assertEqual(Q.popleft(), 'b')
+
+            self.assertRaises(IndexError, Q.pop)
+            self.assertRaises(IndexError, Q.popleft)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_lists.py
+++ b/tests/test_lists.py
@@ -360,6 +360,7 @@ class ListTest(RedisTestCase):
 
         for L in (redis_list, redis_cached, python_list):
             self.assertEqual(L + ['x', 'y'], [0, 1, 2, 3, 'x', 'y'])
+            self.assertEqual(['x', 'y'] + L, ['x', 'y', 0, 1, 2, 3])
 
     def test_mul(self):
         data = (0, 1)


### PR DESCRIPTION
Re: #6, this PR adds a Redis-backed `Deque` class.

This one is based on the Python 3.5 version, and thus includes `insert`, `__add__`, and `__mul__`.

`Deque` is a subclass of `List`, which I changed to make a bit more flexible.

Do note that if you attach a `List` to the same collection you can break the `maxlen`.