### PR TITLE
Equality testing

### DIFF
--- a/tests/test_dicts.py
+++ b/tests/test_dicts.py
@@ -374,6 +374,22 @@ class DictTest(RedisTestCase):
 
         self.assertIn("{0: {1: 2}}", repr(redis_dict))
 
+    def test_eq(self):
+        data = {'a': 1, 'b': 2}
+        redis_dict = self.create_dict(data)
+        redis_cached = self.create_dict(data)
+        python_dict = data.copy()
+
+        self.assertEqual(redis_dict, python_dict)
+        self.assertEqual(python_dict, redis_dict)
+
+        self.assertEqual(redis_cached, python_dict)
+        self.assertEqual(python_dict, redis_cached)
+
+        self.assertNotEqual(redis_dict, data.items())
+        self.assertNotEqual(redis_cached, data.items())
+        self.assertNotEqual(python_dict, data.items())
+
 
 class CounterTest(RedisTestCase):
 

--- a/tests/test_lists.py
+++ b/tests/test_lists.py
@@ -41,6 +41,15 @@ class ListTest(RedisTestCase):
             self.assertIn(3, L)
             self.assertNotIn(4, L)
 
+    def test_equal(self):
+        data = (0, 1, 2, 3)
+        for init in (self.create_list, list):
+            L = init(data)
+            self.assertTrue(L == list(data))
+            self.assertTrue(list(data) == L)
+            self.assertFalse(L == data)
+            self.assertFalse(data == L)
+
     def test_get_set_del_index(self):
         data = ('zero', 'one', 'two', 'three')
         for i in (0, 1, 2, 3, -1, -2, -3, -4):

--- a/tests/test_sets.py
+++ b/tests/test_sets.py
@@ -55,6 +55,7 @@ class SetTest(RedisTestCase):
             self.assertNotEqual(s_1, s_3)
             self.assertEqual(s_2, s_3)
             self.assertEqual(s_3, s_3)
+            self.assertNotEqual(s_3, [4, 5])
 
     def test_disjoint(self):
         for init in (self.create_set, set):
@@ -75,6 +76,7 @@ class SetTest(RedisTestCase):
             s_3 = {1, 2, 3, 4}
             s_4 = {1, 2}
             s_5 = [1, 2, 3, 4]
+            s_6 = self.create_set([1, 2, 3, 4])
 
             self.assertTrue(s_1.issubset(s_2))
             self.assertFalse(s_1 == s_2)
@@ -96,6 +98,10 @@ class SetTest(RedisTestCase):
                 self.assertRaises(TypeError, lambda: s_1 <= s_5)
 
             self.assertRaises(TypeError, s_1.issubset, None)
+
+            self.assertNotEqual(s_1, s_6)
+            self.assertTrue(s_2 == s_6)
+            self.assertTrue(s_6 == s_6)
 
     def test_superset(self):
         for init in (self.create_set, set):


### PR DESCRIPTION
Re: #68, this PR ensures testing for `__eq__` for the various collections and fixes up a race condition when comparing two Redis collections.

There is probably some more work to be done here. There is [discussion now in python-ideas](https://groups.google.com/forum/#!topic/python-ideas/wzMHaloezds) about how classes that inherit from `collections.abc.Sequence` should behave w.r.t equality testing, but for now I'll settle for fixing race conditions and unit testing.

This is for 0.3.0 - see #59.