### PR TITLE
Travis badge point to master

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 Redis Collections
 =================
 
-.. image:: https://travis-ci.org/honzajavorek/redis-collections.svg
+.. image:: https://travis-ci.org/honzajavorek/redis-collections.svg?branch=master
    :target: https://travis-ci.org/honzajavorek/redis-collections
 
 .. image:: https://coveralls.io/repos/github/honzajavorek/redis-collections/badge.svg?branch=master


### PR DESCRIPTION
This PR changes the badge on the front-page README such that experiments on other branches don't cause it to show the build as failing.