### PR TITLE
Use license type in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
     author=meta['author'],
     author_email='mail@honzajavorek.cz',
     url='https://github.com/honzajavorek/redis-collections',
-    license=io.open('LICENSE', encoding='utf-8').read(),
+    license='ISC',
     packages=find_packages(exclude=['tests']),
     include_package_data=True,
     install_requires=['redis>=2.7.2', 'six>=1.10.0'],


### PR DESCRIPTION
Re: #39, our setup.py file currently reads in the entire license file, rather than naming the type of license.

[PyPA](http://python-packaging-user-guide.readthedocs.io/distributing/#license) recommends naming the type, so this PR changes setup.py to do that.