### PR TITLE
Build universal wheels

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ deploy:
     python: "2.7"
     tags: true
     repo: "honzajavorek/redis-collections"
+    distributions: "sdist bdist_wheel"
 
 notifications:
   email: false

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,6 @@
+[bdist_wheel]
+universal = 1
+
 [flake8]
 exclude = ./docs/conf.py
 ignore = E731


### PR DESCRIPTION
Re: #39, this PR changes the Travis CI configuration to build a ["universal" wheel](http://python-packaging-user-guide.readthedocs.io/distributing/#universal-wheels).

This applies because we're:
* Pure Python (i.e. no C extensions)
* Compatible with Python 2 and Python 3 without changes (i.e. no 2to3)