### PR TITLE
Set.random_sample for Redis < 2.6.0

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -185,6 +185,11 @@ Philosophy
 *   Behavior of **nested Redis Collections** containing other Redis Collections is **undefined**.
     It is not recommended to create such structures. Use collection of keys instead.
 
+*   Redis Collections will take advantage of features in new versions of Redis, but will provide backports for older versions of Redis.
+
+    The earliest supported version of Redis is the one that ships with the oldest supported LTS release of Ubuntu Linux
+    (see `packages.ubuntu.com <http://packages.ubuntu.com/redis-server>`_).
+
 API Documentation
 -----------------
 

--- a/redis_collections/base.py
+++ b/redis_collections/base.py
@@ -45,6 +45,9 @@ class RedisCollection(object):
         #: Redis client instance. :class:`StrictRedis` object with default
         #: connection settings is used if not set by :func:`__init__`.
         self.redis = redis or self._create_redis()
+        self.redis_version = tuple(
+            int(x) for x in self.redis.info()['redis_version'].split('.')
+        )
 
         #: Redis key of the collection.
         self.key = key or self._create_key()

--- a/tests/test_sets.py
+++ b/tests/test_sets.py
@@ -364,12 +364,16 @@ class SetTest(RedisTestCase):
         self.assertEqual(s.random_sample(0), [])
         self.assertEqual(s.random_sample(), ['a'])
 
-        redis_version = self.redis.info()['redis_version']
-        redis_version = [int(x) for x in redis_version.split('.')]
-        major_ver, minor_ver, _ = redis_version
-        if (major_ver > 2) or (major_ver >= 2 and minor_ver >= 6):
-            s = self.create_set('ab')
-            self.assertEqual(sorted(s.random_sample(2)), ['a', 'b'])
+        s = self.create_set('ab')
+        self.assertEqual(sorted(s.random_sample(-2)), ['a', 'b'])
+        self.assertEqual(sorted(s.random_sample(2)), ['a', 'b'])
+        self.assertEqual(sorted(s.random_sample(3)), ['a', 'b'])
+
+        # Test like this is an old version of Redis
+        s.redis_version = (2, 4, 0)
+        self.assertEqual(sorted(s.random_sample(-2)), ['a', 'b'])
+        self.assertEqual(sorted(s.random_sample(2)), ['a', 'b'])
+        self.assertEqual(sorted(s.random_sample(3)), ['a', 'b'])
 
     def test_add_unicode(self):
         for init in (self.create_set, set):


### PR DESCRIPTION
Re: #74, this PR:
* Adds support for the `k` argument in `Set.random_sample` when the Redis server version is < 2.6.0
* Documents the Redis version support policy described in the issue