### PR TITLE
Sync-able collections

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,7 +21,7 @@ Installation
 Example
 -------
 
-Redis Collections provide a simple, Pythonic way how access Redis structures:
+Redis Collections provide a simple, Pythonic way to access Redis structures:
 
 .. code:: python
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -233,6 +233,9 @@ Redis Collections are composed of only several classes. All items listed below a
     :members:
     :special-members:
 
+.. automodule:: redis_collections.syncable
+    :members:
+
 Changelog
 ---------
 

--- a/redis_collections/__init__.py
+++ b/redis_collections/__init__.py
@@ -13,6 +13,13 @@ from .dicts import DefaultDict, Dict, Counter  # NOQA
 from .lists import Deque, List  # NOQA
 from .sets import Set  # NOQA
 from .sortedsets import SortedSetCounter  # NOQA
+from .syncable import (
+    SyncableDict,
+    SyncableCounter,
+    SyncableDefaultDict,
+    SyncableList,
+    SyncableSet,
+)  # NOQA
 
 __all__ = [
     'Counter',
@@ -23,4 +30,9 @@ __all__ = [
     'RedisCollection',
     'Set',
     'SortedSetCounter',
+    'SyncableDict',
+    'SyncableCounter',
+    'SyncableDefaultDict',
+    'SyncableList',
+    'SyncableSet',
 ]

--- a/redis_collections/syncable.py
+++ b/redis_collections/syncable.py
@@ -12,7 +12,7 @@ executes, or call the :func:`sync` method explicitly.
 
     >>> with SyncableDict() as D:
     ...     D['one'] = 1
-    ... 
+    ...
     >>> D  # Contents are available locally and are stored in Redis
     {'one': 1}
     >>> D['two'] = 2  # Changes are available locally, but not in Redis...
@@ -59,7 +59,7 @@ class SyncableDict(_SyncableBase, dict):
     <https://docs.python.org/3/library/stdtypes.html#mapping-types-dict>`_ for
     details.
     """
-    
+
     def __init__(self, **kwargs):
         self.persistence = Dict(**kwargs)
 
@@ -76,8 +76,8 @@ class SyncableCounter(_SyncableBase, collections.Counter):
     Redis.
 
     See Python's `Counter documentation
-    <https://docs.python.org/3/library/collections.html#collections.Counter>`_ for
-    details.    
+    <https://docs.python.org/3/library/collections.html#collections.Counter>`_
+    for details.
     """
 
     def __init__(self, **kwargs):

--- a/redis_collections/syncable.py
+++ b/redis_collections/syncable.py
@@ -26,9 +26,6 @@ be loaded.
     >>> E = SyncableDict(key='f4a78a6faacb4d8e97829f9888ac6740')
     >>> E
     {'one': 1, 'two': 2}
-
-
-
 """
 from __future__ import division, print_function, unicode_literals
 

--- a/redis_collections/syncable.py
+++ b/redis_collections/syncable.py
@@ -3,12 +3,32 @@
 syncable
 ~~~~~
 
-Persistent Python collections that can be manually synchronized to and
-retrieved from Redis.
-
+Persistent Python collections that can be written to and read from Redis.
 The collections are kept in memory, so their operations run as fast as their
-standard counterparts'. When their :func:`sync` method is called their contents
-are written to Redis.
+standard counterparts'.
+
+Use in a ``with`` block to automatically sync to Redis after the block
+executes, or call the :func:`sync` method explicitly.
+
+    >>> with SyncableDict() as D:
+    ...     D['one'] = 1
+    ... 
+    >>> D  # Contents are available locally and are stored in Redis
+    {'one': 1}
+    >>> D['two'] = 2  # Changes are available locally, but not in Redis...
+    >>> D.sync()  # ...until sync is called.
+
+If you specify a ``key`` pointing to an existing collection, its contents will
+be loaded.
+
+    >>> D.key
+    'f4a78a6faacb4d8e97829f9888ac6740'
+    >>> E = SyncableDict(key='f4a78a6faacb4d8e97829f9888ac6740')
+    >>> E
+    {'one': 1, 'two': 2}
+
+
+
 """
 from __future__ import division, print_function, unicode_literals
 
@@ -20,6 +40,10 @@ from .sets import Set
 
 
 class _SyncableBase(object):
+    @property
+    def key(self):
+        return self.persistence.key
+
     def __enter__(self):
         return self
 
@@ -28,9 +52,16 @@ class _SyncableBase(object):
 
 
 class SyncableDict(_SyncableBase, dict):
-    def __init__(self, redis=None, key=None):
-        self.persistence = Dict(redis=redis, key=key)
-        self.key = self.persistence.key
+    """
+    :class:`dict` subclass whose contents can be synced to Redis.
+
+    See Python's `dict documentation
+    <https://docs.python.org/3/library/stdtypes.html#mapping-types-dict>`_ for
+    details.
+    """
+    
+    def __init__(self, **kwargs):
+        self.persistence = Dict(**kwargs)
 
         super(SyncableDict, self).__init__()
         self.update(self.persistence)
@@ -40,9 +71,17 @@ class SyncableDict(_SyncableBase, dict):
 
 
 class SyncableCounter(_SyncableBase, collections.Counter):
-    def __init__(self, redis=None, key=None):
-        self.persistence = Counter(redis=redis, key=key)
-        self.key = self.persistence.key
+    """
+    :class:`collections.Counter` subclass whose contents can be synced to
+    Redis.
+
+    See Python's `Counter documentation
+    <https://docs.python.org/3/library/collections.html#collections.Counter>`_ for
+    details.    
+    """
+
+    def __init__(self, **kwargs):
+        self.persistence = Counter(**kwargs)
 
         super(SyncableCounter, self).__init__()
         self.update(self.persistence)
@@ -53,11 +92,19 @@ class SyncableCounter(_SyncableBase, collections.Counter):
 
 
 class SyncableDefaultDict(_SyncableBase, collections.defaultdict):
-    def __init__(self, default_factory=None, redis=None, key=None):
-        self.persistence = DefaultDict(default_factory, redis=redis, key=key)
-        self.key = self.persistence.key
+    """
+    :class:`collections.defaultdict` subclass whose contents can be synced to
+    Redis.
 
-        super(SyncableDefaultDict, self).__init__(default_factory)
+    See Python's `defaultdict documentation
+    <https://docs.python.org/3/library/collections.html
+    #collections.defaultdict>`_ for details.
+    """
+
+    def __init__(self, *args, **kwargs):
+        self.persistence = DefaultDict(*args, **kwargs)
+
+        super(SyncableDefaultDict, self).__init__(args[0] if args else None)
         self.update(self.persistence)
 
     def sync(self):
@@ -65,9 +112,16 @@ class SyncableDefaultDict(_SyncableBase, collections.defaultdict):
 
 
 class SyncableList(_SyncableBase, list):
-    def __init__(self, redis=None, key=None):
-        self.persistence = List(redis=redis, key=key)
-        self.key = self.persistence.key
+    """
+    :class:`list` subclass whose contents can be synced to Redis.
+
+    See Python's `list documentation
+    <https://docs.python.org/3/library/stdtypes.html
+    #sequence-types-list-tuple-range>`_ for details.
+    """
+
+    def __init__(self, **kwargs):
+        self.persistence = List(**kwargs)
 
         super(SyncableList, self).__init__()
         self.extend(self.persistence)
@@ -78,9 +132,16 @@ class SyncableList(_SyncableBase, list):
 
 
 class SyncableSet(_SyncableBase, set):
-    def __init__(self, redis=None, key=None):
-        self.persistence = Set(redis=redis, key=key)
-        self.key = self.persistence.key
+    """
+    :class:`set` subclass whose contents can be synced to Redis.
+
+    See Python's `set documentation
+    <https://docs.python.org/3/library/stdtypes.html
+    #set-types-set-frozenset>`_ for details.
+    """
+
+    def __init__(self, **kwargs):
+        self.persistence = Set(**kwargs)
 
         super(SyncableSet, self).__init__()
         self.update(self.persistence)

--- a/redis_collections/syncable.py
+++ b/redis_collections/syncable.py
@@ -1,0 +1,90 @@
+# -*- coding: utf-8 -*-
+"""
+syncable
+~~~~~
+
+Persistent Python collections that can be manually synchronized to and
+retrieved from Redis.
+
+The collections are kept in memory, so their operations run as fast as their
+standard counterparts'. When their :func:`sync` method is called their contents
+are written to Redis.
+"""
+from __future__ import division, print_function, unicode_literals
+
+import collections
+
+from .dicts import Counter, DefaultDict, Dict
+from .lists import List
+from .sets import Set
+
+
+class _SyncableBase(object):
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.sync()
+
+
+class SyncableDict(_SyncableBase, dict):
+    def __init__(self, redis=None, key=None):
+        self.persistence = Dict(redis=redis, key=key)
+        self.key = self.persistence.key
+
+        super(SyncableDict, self).__init__()
+        self.update(self.persistence)
+
+    def sync(self):
+        self.persistence.update(self)
+
+
+class SyncableCounter(_SyncableBase, collections.Counter):
+    def __init__(self, redis=None, key=None):
+        self.persistence = Counter(redis=redis, key=key)
+        self.key = self.persistence.key
+
+        super(SyncableCounter, self).__init__()
+        self.update(self.persistence)
+
+    def sync(self):
+        self.persistence.clear()
+        self.persistence.update(self)
+
+
+class SyncableDefaultDict(_SyncableBase, collections.defaultdict):
+    def __init__(self, default_factory=None, redis=None, key=None):
+        self.persistence = DefaultDict(default_factory, redis=redis, key=key)
+        self.key = self.persistence.key
+
+        super(SyncableDefaultDict, self).__init__(default_factory)
+        self.update(self.persistence)
+
+    def sync(self):
+        self.persistence.update(self)
+
+
+class SyncableList(_SyncableBase, list):
+    def __init__(self, redis=None, key=None):
+        self.persistence = List(redis=redis, key=key)
+        self.key = self.persistence.key
+
+        super(SyncableList, self).__init__()
+        self.extend(self.persistence)
+
+    def sync(self):
+        self.persistence.clear()
+        self.persistence.extend(self)
+
+
+class SyncableSet(_SyncableBase, set):
+    def __init__(self, redis=None, key=None):
+        self.persistence = Set(redis=redis, key=key)
+        self.key = self.persistence.key
+
+        super(SyncableSet, self).__init__()
+        self.update(self.persistence)
+
+    def sync(self):
+        self.persistence.clear()
+        self.persistence.update(self)

--- a/tests/test_syncable.py
+++ b/tests/test_syncable.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+from __future__ import division, print_function, unicode_literals
+
+import unittest
+
+from redis_collections import (
+    SyncableDict,
+    SyncableCounter,
+    SyncableDefaultDict,
+    SyncableList,
+    SyncableSet,
+)
+
+from .base import RedisTestCase
+
+
+class SyncableTest(RedisTestCase):
+
+    def create_collection(self, cls, *args, **kwargs):
+        kwargs['redis'] = self.redis
+        return cls(*args, **kwargs)
+
+    def test_dict(self):
+        dict_1 = self.create_collection(SyncableDict)
+
+        # Setting a key should set it in Python but not in Redis
+        dict_1['a'] = 1
+        self.assertEqual(dict_1['a'], 1)
+        self.assertNotIn('a', dict_1.persistence)
+
+        # Synchronizing should set the key in Redis
+        dict_1.sync()
+        self.assertEqual(dict_1.persistence['a'], 1)
+
+        # Using a with block should automatically synchronize
+        key_1 = dict_1.key
+        with self.create_collection(SyncableDict, key=key_1) as dict_2:
+            self.assertEqual(dict_2['a'], 1)
+
+            dict_2['b'] = 2
+        self.assertEqual(dict_2.persistence['b'], 2)
+
+        # Modifying the second dict shouldn't affect the first
+        self.assertNotEqual(dict_1, dict_2)
+
+    def test_Counter(self):
+        counter_1 = self.create_collection(SyncableCounter)
+
+        counter_1['a'] = 1
+        self.assertEqual(counter_1['a'], 1)
+        self.assertNotIn('a', counter_1.persistence)
+
+        counter_1.sync()
+        self.assertEqual(counter_1.persistence['a'], 1)
+
+        key_1 = counter_1.key
+        with self.create_collection(SyncableCounter, key=key_1) as counter_2:
+            self.assertEqual(counter_2['a'], 1)
+
+            counter_2['b'] = 2
+
+        # Update is special for Counter - make sure contents can be retrieved
+        # again unchanged.
+        with self.create_collection(SyncableCounter, key=key_1) as counter_3:
+            self.assertEqual(counter_3['a'], 1)
+            self.assertEqual(counter_3['b'], 2)
+
+        # The counter should behave like a Counter
+        self.assertEqual(counter_3.most_common(), [('b', 2), ('a', 1)])
+
+    def test_defaultdict(self):
+        ddict_1 = self.create_collection(SyncableDefaultDict, int)
+
+        # The first argument to defaultdict is the default_factory - it should
+        # be set both for the defaultdict and the DefaultDict
+        self.assertEqual(ddict_1.default_factory, int)
+        self.assertEqual(ddict_1.persistence.default_factory, int)
+
+        # The defaultdict should behave like a defaultdict
+        self.assertEqual(ddict_1['a'], 0)
+        ddict_1['a'] += 1
+        self.assertEqual(ddict_1['a'], 1)
+        self.assertNotIn('a', ddict_1.persistence)
+
+        ddict_1.sync()
+        self.assertEqual(ddict_1.persistence['a'], 1)
+
+        # The default_factory can be changed between synchronizations
+        key_1 = ddict_1.key
+        with self.create_collection(
+            SyncableDefaultDict, set, key=key_1
+        ) as ddict_2:
+            self.assertEqual(ddict_2['a'], 1)
+            self.assertEqual(ddict_2.default_factory, set)
+
+    def test_list(self):
+        list_1 = self.create_collection(SyncableList)
+
+        list_1.append('a')
+        self.assertEqual(list_1, ['a'])
+        self.assertEqual(list_1.persistence, [])
+
+        list_1.sync()
+        self.assertEqual(list_1.persistence, ['a'])
+
+        key_1 = list_1.key
+        with self.create_collection(SyncableList, key=key_1) as list_2:
+            self.assertEqual(list_2, ['a'])
+
+            list_2.append('b')
+
+        self.assertEqual(list_2.persistence, ['a', 'b'])
+
+        self.assertNotEqual(list_1, list_2)
+
+    def test_set(self):
+        set_1 = self.create_collection(SyncableSet)
+
+        set_1.add('a')
+        self.assertEqual(set_1, {'a'})
+        self.assertEqual(set_1.persistence, set())
+
+        set_1.sync()
+        self.assertEqual(set_1.persistence, {'a'})
+
+        key_1 = set_1.key
+        with self.create_collection(SyncableSet, key=key_1) as set_2:
+            self.assertEqual(set_2, {'a'})
+
+            set_2.add('b')
+
+        self.assertEqual(set_2.persistence, {'a', 'b'})
+
+        self.assertNotEqual(set_1, set_2)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Re: #79, this PR introduces a slate of "sync-able" collections, which allow you to work with Python `dict`s, `list`s, `set`s, etc. at normal speed (that is, without the slowness associated with sending to and receiving from Redis), but easily synchronize those collections to Redis.

---

__Usage__: Using a `with` block will automatically write changes to Redis
```python
>>> with SyncableDict() as D:
...     D['one'] = 1
...
>>> D  # Contents are available locally and are stored in Redis
{'one': 1}
>>> D['two'] = 2  # Changes are available locally, but not in Redis...
>>> D.sync()  # ...until sync is called.
```

You can attach to an earlier collection as well:
```python
>>> D.key
'f4a78a6faacb4d8e97829f9888ac6740'
>>> E = SyncableDict(key='f4a78a6faacb4d8e97829f9888ac6740')
>>> E
{'one': 1, 'two': 2}
```

---

__The meta-question__:  This seemed like a great idea when I first thought of, it but it is possible to achieve the same thing with existing code.

```python
python_dict = {}
redis_dict = Dict()

try:
    python_dict['a'] = 1
    # Do other stuff at Python speed
finally:
    redis_dict.update(python_dict)
```

I *think* this new interface provides enough convenience to justify its existence. @honzajavorek, do you agree?