### PR TITLE
Switch from cPickle to pickle on Python 2

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -167,6 +167,10 @@ If you are not satisfied with that function's `collision probability <http://sta
 If you don't like how  :mod:`pickle` does serialization, you may override the ``_pickle`` and ``_unpickle`` methods of the collection classes.
 Using other serializers may limit the objects you can store or retrieve.
 
+.. note::
+    On Python 2, the :mod:`pickle` module is used instead of the :mod:`cPickle` module.
+    This is intentional - see `issue #83 <https://github.com/honzajavorek/redis-collections/issues/83>`_.
+
 Philosophy
 ----------
 

--- a/redis_collections/base.py
+++ b/redis_collections/base.py
@@ -10,10 +10,9 @@ from decimal import Decimal
 from fractions import Fraction
 import uuid
 
-try:
-    import cPickle as pickle
-except ImportError:
-    import pickle as pickle  # NOQA
+# We use pickle instead of cPickle on Python 2 intentionally, see
+# http://bugs.python.org/issue5518
+import pickle
 
 import redis
 import six


### PR DESCRIPTION
See #83 for the motivation. This at least solves the issue for the test case:

```python
>>> from redis_collections import Set
... s = Set()
... key = (1, u'foo')
... s.add((1, u'foo'))
>>> (1, u'foo') in s
0: True
>>> key in s
1: True
```

`Set` and `Dict` on Python 2 should now behave better; no change for Python 3.