### PR TITLE
Test for pipe properly

### DIFF
--- a/redis_collections/base.py
+++ b/redis_collections/base.py
@@ -150,7 +150,7 @@ class RedisCollection(object):
         :type pipe: :class:`redis.client.StrictPipeline` or
                     :class:`redis.client.StrictRedis`
         """
-        redis = pipe or self.redis
+        redis = self.redis if pipe is None else pipe
         redis.delete(self.key)
 
     def _same_redis(self, other, cls=None):

--- a/redis_collections/dicts.py
+++ b/redis_collections/dicts.py
@@ -76,12 +76,12 @@ class Dict(RedisCollection, collections.MutableMapping):
 
     def __len__(self, pipe=None):
         """Return the number of items in the dictionary."""
-        pipe = pipe or self.redis
+        pipe = self.redis if pipe is None else pipe
         return pipe.hlen(self.key)
 
     def __iter__(self, pipe=None):
         """Return an iterator over the keys of the dictionary."""
-        pipe = pipe or self.redis
+        pipe = self.redis if pipe is None else pipe
         for k, v in six.iteritems(self._data(pipe)):
             yield k
 
@@ -172,7 +172,7 @@ class Dict(RedisCollection, collections.MutableMapping):
         Returns a Python dictionary with the same values as this object
         (without checking the local cache).
         """
-        pipe = pipe or self.redis
+        pipe = self.redis if pipe is None else pipe
         items = six.iteritems(pipe.hgetall(self.key))
 
         return {self._unpickle(k): self._unpickle(v) for k, v in items}
@@ -183,7 +183,7 @@ class Dict(RedisCollection, collections.MutableMapping):
 
     def iteritems(self, pipe=None):
         """Return an iterator over the dictionary's ``(key, value)`` pairs."""
-        pipe = pipe or self.redis
+        pipe = self.redis if pipe is None else pipe
         for k, v in six.iteritems(self._data(pipe)):
             yield k, self.cache.get(k, v)
 

--- a/redis_collections/dicts.py
+++ b/redis_collections/dicts.py
@@ -51,8 +51,8 @@ class Dict(RedisCollection, collections.MutableMapping):
         :param redis: Redis client instance. If not provided, default Redis
                       connection is used.
         :type redis: :class:`redis.StrictRedis`
-        :param key: Redis key of the collection. Collections with the same key
-                    point to the same data. If not provided, default random
+        :param key: Redis key for the collection. Collections with the same key
+                    point to the same data. If not provided, a random
                     string is generated.
         :type key: str
         :param writeback: If ``True`` keep a local cache of changes for storing
@@ -398,8 +398,8 @@ class Counter(Dict):
         :param redis: Redis client instance. If not provided, default Redis
                       connection is used.
         :type redis: :class:`redis.StrictRedis`
-        :param key: Redis key of the collection. Collections with the same key
-                    point to the same data. If not provided, default random
+        :param key: Redis key for the collection. Collections with the same key
+                    point to the same data. If not provided, a random
                     string is generated.
         :type key: str
 
@@ -628,8 +628,8 @@ class DefaultDict(Dict):
         :param redis: Redis client instance. If not provided, default Redis
                       connection is used.
         :type redis: :class:`redis.StrictRedis`
-        :param key: Redis key of the collection. Collections with the same key
-                    point to the same data. If not provided, default random
+        :param key: Redis key for the collection. Collections with the same key
+                    point to the same data. If not provided, a random
                     string is generated.
         :type key: str
 

--- a/redis_collections/lists.py
+++ b/redis_collections/lists.py
@@ -33,8 +33,8 @@ class List(RedisCollection, collections.MutableSequence):
         :param redis: Redis client instance. If not provided, default Redis
                       connection is used.
         :type redis: :class:`redis.StrictRedis`
-        :param key: Redis key of the collection. Collections with the same key
-                    point to the same data. If not provided, default random
+        :param key: Redis key for the collection. Collections with the same key
+                    point to the same data. If not provided, a random
                     string is generated.
         :type key: str
         :param writeback: If ``True`` keep a local cache of changes for storing
@@ -635,8 +635,8 @@ class Deque(List):
         :param redis: Redis client instance. If not provided, default Redis
                       connection is used.
         :type redis: :class:`redis.StrictRedis`
-        :param key: Redis key of the collection. Collections with the same key
-                    point to the same data. If not provided, default random
+        :param key: Redis key for the collection. Collections with the same key
+                    point to the same data. If not provided, a random
                     string is generated.
         :type key: str
         :param writeback: If ``True`` keep a local cache of changes for storing

--- a/redis_collections/sets.py
+++ b/redis_collections/sets.py
@@ -51,7 +51,7 @@ class Set(RedisCollection, collections.MutableSet):
             self.update(data)
 
     def _data(self, pipe=None):
-        pipe = pipe or self.redis
+        pipe = self.redis if pipe is None else pipe
         return (self._unpickle(x) for x in pipe.smembers(self.key))
 
     def _repr_data(self):
@@ -62,17 +62,17 @@ class Set(RedisCollection, collections.MutableSet):
 
     def __contains__(self, value, pipe=None):
         """Test for membership of *value* in the set."""
-        pipe = pipe or self.redis
+        pipe = self.redis if pipe is None else pipe
         return bool(pipe.sismember(self.key, self._pickle(value)))
 
     def __iter__(self, pipe=None):
         """Return an iterator over elements of the set."""
-        pipe = pipe or self.redis
+        pipe = self.redis if pipe is None else pipe
         return self._data(pipe)
 
     def __len__(self, pipe=None):
         """Return cardinality of the set."""
-        pipe = pipe or self.redis
+        pipe = self.redis if pipe is None else pipe
         return pipe.scard(self.key)
 
     # Named methods

--- a/redis_collections/sets.py
+++ b/redis_collections/sets.py
@@ -39,8 +39,8 @@ class Set(RedisCollection, collections.MutableSet):
         :param redis: Redis client instance. If not provided, default Redis
                       connection is used.
         :type redis: :class:`redis.StrictRedis`
-        :param key: Redis key of the collection. Collections with the same key
-                    point to the same data. If not provided, default random
+        :param key: Redis key for the collection. Collections with the same key
+                    point to the same data. If not provided, a random
                     string is generated.
         :type key: str
         """

--- a/redis_collections/sortedsets.py
+++ b/redis_collections/sortedsets.py
@@ -54,8 +54,8 @@ class SortedSetCounter(RedisCollection):
         :param redis: Redis client instance. If not provided, default Redis
                       connection is used.
         :type redis: :class:`redis.StrictRedis`
-        :param key: Redis key of the collection. Collections with the same key
-                    point to the same data. If not provided, default random
+        :param key: Redis key for the collection. Collections with the same key
+                    point to the same data. If not provided, a random
                     string is generated.
         :type key: str
         """
@@ -79,7 +79,7 @@ class SortedSetCounter(RedisCollection):
     # Magic methods
 
     def __contains__(self, member, pipe=None):
-        """Return ``True`` if *key* is present, else ``False``."""
+        """Return ``True`` if *member* is present, else ``False``."""
         pipe = self.redis if pipe is None else pipe
         score = pipe.zscore(self.key, self._pickle(member))
 

--- a/redis_collections/syncable.py
+++ b/redis_collections/syncable.py
@@ -176,7 +176,7 @@ class LRUDict(_SyncableBase, collections.MutableMapping):
         :param redis: Redis client instance. If not provided, default Redis
                       connection is used.
         :type redis: :class:`redis.StrictRedis`
-        :param key: Redis key of the collection. Collections with the same key
+        :param key: Redis key for the collection. Collections with the same key
                     point to the same data. If not provided, a random
                     string is generated.
         :type key: str


### PR DESCRIPTION
In ca30e7dcdb457432ac1f9fdc745c0da13bd00785, @icecrime pointed out a potential pitfall with using the `thing = thing or get_thing()` idiom. This is incorrect to use for determining whether to use a redis-py `pipeline` instance or not, since the pipeline can evaluate to `False`. This PR removes that idiom from the various collections.

The base for this PR is #86 to avoid merge conflicts.