### PR TITLE
Clear syncable Dicts

### DIFF
--- a/redis_collections/syncable.py
+++ b/redis_collections/syncable.py
@@ -68,6 +68,7 @@ class SyncableDict(_SyncableBase, dict):
         self.update(self.persistence)
 
     def sync(self):
+        self.persistence.clear()
         self.persistence.update(self)
 
 
@@ -109,6 +110,7 @@ class SyncableDefaultDict(_SyncableBase, collections.defaultdict):
         self.update(self.persistence)
 
     def sync(self):
+        self.persistence.clear()
         self.persistence.update(self)
 
 
@@ -273,6 +275,7 @@ class LRUDict(_SyncableBase, collections.MutableMapping):
         If *clear_cache* is ``True``, clear out the local cache after
         pushing its items to Redis.
         """
+        self.persistence.clear()
         self.persistence.update(self)
 
         if clear_cache:

--- a/redis_collections/syncable.py
+++ b/redis_collections/syncable.py
@@ -275,7 +275,6 @@ class LRUDict(_SyncableBase, collections.MutableMapping):
         If *clear_cache* is ``True``, clear out the local cache after
         pushing its items to Redis.
         """
-        self.persistence.clear()
         self.persistence.update(self)
 
         if clear_cache:

--- a/tests/test_syncable.py
+++ b/tests/test_syncable.py
@@ -35,6 +35,14 @@ class SyncableTest(RedisTestCase):
         dict_1.sync()
         self.assertEqual(dict_1.persistence['a'], 1)
 
+        # Deleting a key should remove it in Redis after sync
+        dict_1['A'] = 'one'
+        dict_1.sync()
+
+        del dict_1['A']
+        dict_1.sync()
+        self.assertNotIn('A', dict_1.persistence)
+
         # Using a with block should automatically synchronize
         key_1 = dict_1.key
         with self.create_collection(SyncableDict, key=key_1) as dict_2:
@@ -55,6 +63,14 @@ class SyncableTest(RedisTestCase):
 
         counter_1.sync()
         self.assertEqual(counter_1.persistence['a'], 1)
+
+        # Deleting a key should remove it in Redis after sync
+        counter_1['A'] = 100
+        counter_1.sync()
+
+        del counter_1['A']
+        counter_1.sync()
+        self.assertNotIn('A', counter_1.persistence)
 
         key_1 = counter_1.key
         with self.create_collection(SyncableCounter, key=key_1) as counter_2:
@@ -87,6 +103,14 @@ class SyncableTest(RedisTestCase):
 
         ddict_1.sync()
         self.assertEqual(ddict_1.persistence['a'], 1)
+
+        # Deleting a key should remove it in Redis after sync
+        ddict_1['A'] = 100
+        ddict_1.sync()
+
+        del ddict_1['A']
+        ddict_1.sync()
+        self.assertNotIn('A', ddict_1.persistence)
 
         # The default_factory can be changed between synchronizations
         key_1 = ddict_1.key


### PR DESCRIPTION
This PR fixes a bug with `SyncableDict` and `SyncableDefaultDict` - after deleting a key from a collection that's been synchronized, it should not stay around in Redis after the next synchronization. It also adds test for this behavior.