### PR TITLE
Re-organize docs

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,0 +1,54 @@
+.. _api:
+
+API Documentation
+=================
+
+Redis Collections are composed of only several classes. All items listed below
+are exposed as public API, so you can (and you should) import them directly
+from ``redis_collections`` package.
+
+.. automodule:: redis_collections.base
+
+.. autoclass:: RedisCollection
+    :members:
+    :special-members:
+    :exclude-members: __metaclass__, __weakref__
+
+.. automodule:: redis_collections.dicts
+
+.. autoclass:: Dict
+    :members:
+    :special-members:
+
+.. autoclass:: Counter
+    :members:
+    :special-members:
+
+.. autoclass:: DefaultDict
+    :members:
+    :special-members:
+
+.. automodule:: redis_collections.lists
+
+.. autoclass:: List
+    :members:
+    :special-members:
+
+.. autoclass:: Deque
+    :members:
+    :special-members:
+
+.. automodule:: redis_collections.sets
+
+.. autoclass:: Set
+    :members:
+    :special-members:
+
+.. automodule:: redis_collections.sortedsets
+
+.. autoclass:: SortedSetCounter
+    :members:
+    :special-members:
+
+.. automodule:: redis_collections.syncable
+    :members:

--- a/docs/basic-usage.rst
+++ b/docs/basic-usage.rst
@@ -163,6 +163,8 @@ understand and use:
 
 .. code-block:: python
 
+    >>> from redis_collections import SortedSetCounter
+
     >>> ssc = SortedSetCounter([('earth', 300), ('mercury', 100)])
     >>> ssc.set_score('venus', 200)
     >>> ssc.get_score('venus')

--- a/docs/basic-usage.rst
+++ b/docs/basic-usage.rst
@@ -1,0 +1,173 @@
+.. _basic-usage:
+
+Installation and examples
+=========================
+
+Installation
+------------
+
+To get started, install the library with
+`pip <https://pip.pypa.io/en/stable/>`_:
+
+.. code-block:: shell
+
+    pip install redis-collections
+
+
+Basic usage
+-----------
+
+All collections can be imported from the top-level ``redis_collections``
+package. For example, to use a Redis-backed version of Python's ``dict``,
+import ``Dict`` and use it just like you would its Python counterpart:
+
+.. code-block:: python
+
+    >>> from redis_collections import Dict
+
+    >>> D = Dict()
+    >>> D['answer'] = 42  # Store an item on the Redis server
+    >>> D['answer']  # Retrieve an item from the Redis server
+    42
+
+To use a dictionary that pushes its least recently used items to Redis, import
+``LRUDict`` and use it like a normal ``dict``:
+
+.. code-block:: python
+
+    >>> from redis_collections import LRUDict
+
+    >>> lru_dict = LRUDict(maxsize=2)
+    >>> lru_dict.update([('a', 1), ('b', 2), ('c', 3), ('d', 4)])
+    >>> lru_dict['b']  # Most recently used key is now 'b'
+    1
+    >>> lru_dict['c'] = -2  # Most recently used key is now 'c'
+    >>> lru_duct['e'] = 5  # 'e' pushes 'b' to Redis
+
+
+Standard collections
+--------------------
+
+This package provides several collections that emulate built-in Python types
+and classes from the `collections module
+<https://docs.python.org/3/library/collections.html>`_.
+
+=============== ===============  ==========
+Collection      Python type      Redis type
+=============== ===============  ==========
+``Dict``        ``dict``         `Hash`
+``List``        ``list``         `List`
+``Set``         ``set``          `Set`
+--------------- ---------------  ----------
+``Counter``     ``Counter``      `Hash`
+``DefaultDict`` ``defaultdict``  `Hash`
+``Deque``       ``deque``        `List`
+=============== ===============  ==========
+
+Use each one as you would the standard version:
+
+.. code-block:: python
+
+    >>> from redis_collections import List, Set
+
+    >>> L = List(key='test-list')
+    >>> L.append('one')
+    >>> L.extend(['two', 'three'])
+    >>> L[:-1]
+    ['one', 'two']
+
+    >>> S = Set(key='test-set')
+    >>> S.add('a')
+    >>> S.add('a')
+    >>> S.add('b')
+    >>> len(S)
+    2
+
+Data is stored and retrieved in Redis, so if the Python process with a
+collection terminates, you can re-load it in another process.
+
+Syncable collections
+--------------------
+
+The standard Redis collections write to and read from Redis for all operations.
+This means that all changes made in a Python process are reflected in Redis,
+and that a collection made by one Python process can be accessed by another
+Python process. However, this also means that all read and write operations are
+fairly slow, since they have to retrieve data from and write data to Redis.
+
+The syncable collections in this package provide types whose
+contents are kept in memory. When their ``sync`` method is called those contents
+are written to Redis:
+
+.. code-block:: python
+
+    >>> from redis_collections import SyncableDict
+
+    >>> D = SyncableDict()
+    >>> D['a'] = 1  # No write to Redis
+    >>> D['a'] += 1  # No read from or write to Redis
+    >>> D.sync()  # Contents are written to Redis
+
+These collections can also be used with a ``with`` block for automatic
+synchronization:
+
+.. code-block:: python
+
+    >>> with SyncableDict() as D:
+    ...     D['a'] = 1
+    ...     D['a'] += 1
+    >>> D['a']  # Contents were written to Redis at the end of the with block
+    2
+
+If the Python process with a collection terminates, un-synchronized data won't
+be available in Redis.
+
+Other collections
+-----------------
+
+Least recently used dictionary
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The standard collections do their processing in Redis (at the expense of
+speed) and the syncable collections do their processing in Python (at the
+expense of automatic persistence).
+
+The ``LRUDict`` collection provides a compromise. Recently used items are
+stored in memory; older items are pushed to Redis:
+
+.. code-block:: python
+
+    >>> from redis_collections import LRUDict
+
+    >>> D = LRUDict(maxsize=2)
+    >>> D['a'] = 1
+    >>> D['b'] = 2
+    >>> D['c'] = 2  # 'a' is pushed to Redis and 'c' is stored locally
+    >>> D['a']  # 'b' is pushed to Redis and 'a' is retrieved for local storage 
+    1
+    >>> D.sync()  # All items are copied to Redis
+
+See the API Docs for ``LRUDict`` for more details.
+
+Sorted Set counter
+^^^^^^^^^^^^^^^^^^
+
+The standard and syncable collections allow for access to Redis data types
+through corresponding Python data types. However, there are Redis data types
+that don't have an analog in Python.
+
+The ``SortedSetCounter`` provides access to the Redis
+`Sorted Set <http://redis.io/topics/data-types#sorted-sets>`_ type. Its API
+doesn't emulate any Python type's, but should be easy for Python users to
+understand and use:
+
+.. code-block:: python
+
+    >>> ssc = SortedSetCounter([('earth', 300), ('mercury', 100)])
+    >>> ssc.set_score('venus', 200)
+    >>> ssc.get_score('venus')
+    200.0
+    >>> ssc.items()
+    [('mercury', 100.0), ('venus', 200.0), ('earth', 300.0)]
+
+See the API Docs for ``SortedSetCounter`` for more details.

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -1,0 +1,51 @@
+.. _usage-notes:
+
+Development
+===========
+
+See the `GitHub project page
+<https://github.com/honzajavorek/redis-collections/>`_ for source code, to file
+and issue, or to make a code contribution.
+
+Philosophy
+----------
+
+*   All operations should be atomic. Please `report
+    <https://github.com/honzajavorek/redis-collections/issues>`_ race
+    conditions.
+
+*   The standard collections should match the API of their Python counterparts.
+    For these collections, having the same (expected) behavior is more
+    important than processing efficiency.
+
+    If there is more efficient approach than the one complying with the model
+    interface, a new method exposing this approach should be introduced and
+    documented.
+
+    If a collection's behavior doesn't match its standard Python counterpart,
+    and there is no documented warning,  please `create an issue
+    <https://github.com/honzajavorek/redis-collections/issues>`_.
+
+*   Behavior of "nested" collections is **undefined**. It is not recommended
+    to create such structures. Use a collection of keys instead.
+
+*   The library will take advantage of features in new versions of Redis,
+    but will provide backports for older versions of Redis.
+
+    The earliest supported version of Redis is the one that ships with the
+    oldest supported LTS release of Ubuntu Linux (see
+    `packages.ubuntu.com <http://packages.ubuntu.com/redis-server>`_).
+
+Maintainers
+-----------
+
+- Bo Bayles (`@bbayles <http://github.com/bbayles>`_)
+- Honza Javorek (`@honzajavorek <http://github.com/honzajavorek>`_)
+
+License: ISC
+------------
+
+© 2013-? Honza Javorek <mail@honzajavorek>
+
+This work is licensed under `ISC license
+<https://en.wikipedia.org/wiki/ISC_license>`_.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,7 +16,11 @@ including:
 *   Subclasses of several Python types whose instances can automatically or
     manually back up their contents to Redis.
 *   Pythonic wrappers for Redis-specific data types such as `Sorted Sets`.
-    
+
+`redis-collections` builds on
+`redis-py <https://github.com/andymccurdy/redis-py>`_, the well-designed
+Python interface to Redis.
+
 Narrative Documentation
 -----------------------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -29,7 +29,6 @@ Narrative Documentation
 
    basic-usage.rst
    usage-notes.rst
-   development.rst
 
 API Documentation
 -----------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,267 +1,48 @@
-.. Redis Collections documentation master file, created by
-   sphinx-quickstart on Wed Jan  9 17:09:50 2013.
-
 Redis Collections
 =================
 
-`redis-collections` is a library that provides several Python collection types (such as ``Dict``, ``List``, ``Set``, and more) backed by Redis.
-This exposes Redis functionality with a Pythonic interface, and provides a simple way to store Python objects across sessions and processes.
+`redis-collections` is a Python library that provides a high-level
+interface to `Redis <http://redis.io/>`_, the excellent key-value store.
 
-This library builds on `Redis <http://redis.io/>`_, the excellent key-value store, and on `redis-py <https://github.com/andymccurdy/redis-py>`_, the well-designed Python interface for it.
+The library exposes several collection types that interact with Redis,
+including:
 
-Installation and Usage
-----------------------
-
-To get started, install the library with `pip <https://pip.pypa.io/en/stable/>`_:
-
-.. code:: shell
-
-   pip install redis-collections
-
-
-With the library installed, import one the collections and use it to store some data:
-
-    >>> from redis_collections import Dict
-    >>> d = Dict()
-    >>> d['answer'] = 42
-    >>> d
-    <redis_collections.Dict at fe267c1dde5d4f648e7bac836a0168fe {'answer': 42}>
-    >>> d.items()
-    [('answer', 42)]
-
-In Redis you'll see a ``hash`` structure under key ``fe267c1dde5d4f648e7bac836a0168fe``.
-That structure stores a field and value that corresponds to ``{'answer': 42}`` (the key and value are pickled, because Redis can store only strings).
-
-In Python you'll find that the collections can do most everything their Python counterparts can:
-
-    >>> d.update({'hasek': 39, 'jagr': 68})
-    >>> d
-    <redis_collections.Dict at fe267c1dde5d4f648e7bac836a0168fe {'answer': 42, 'jagr': 68, 'hasek': 39}>
-    >>> del d['answer']
-    >>> d
-    <redis_collections.Dict at fe267c1dde5d4f648e7bac836a0168fe {'jagr': 68, 'hasek': 39}>
-
-Persistence
------------
-
-By default, a Redis key is generated when you create a new collection.
-If you specify a key when creating a collection you can retrieve what was stored there previously:
-
-    >>> d.key
-    fe267c1dde5d4f648e7bac836a0168fe
-    >>> e = Dict(key='fe267c1dde5d4f648e7bac836a0168fe')
-    >>> e
-    <redis_collections.Dict at fe267c1dde5d4f648e7bac836a0168fe {'jagr': 68, 'hasek': 39}>
-
-This should even work across processes, meaning if your Python script terminates, you can retrieve its data again from Redis.
-
-Each collection allows you to delete its Redis key with the :func:`clear` method::
-
-    >>> d.clear()
-    >>> d.items()
-    []
-
-
-.. note::
-    You may provide your own key string when creating a collection
-    If there is no corresponding key already in Redis, one will be created.
-    This means you can set up your own way of assigning unique keys dependent on your other code.
-    For example, by using IDs of records from your relational database you can have exactly one unique collection in Redis for every record from your SQL storage.
-
-Redis Connection
-----------------
-
-By default, collections use a new Redis connection with its default values.
-This requires no configuration, but is inefficient if you plan to use multiple collections.
-To share a connection among multiple collections, create one (with ``redis.StrictRedis``) and pass it using the ``redis`` keyword when creating the collections:
-
-    >>> from redis import StrictRedis
-    >>> conn = StrictRedis()
-    >>> d = Dict(redis=conn)
-    >>> l = List(redis=conn)  # using the same connection as Dict above
-
-A collection's ``copy`` method creates new a instance that uses the same Redis connection as the original object::
-
-    >>> conn = StrictRedis()
-    >>> list_01 = List([1, 2], redis=conn)
-    >>> list_01
-    <redis_collections.List at 196e407f8fc142728318a999ec821368 [1, 2]>
-    >>> list_02 = list_01.copy()  # result is using the same connection
-    <redis_collections.List at 7790ef98639043c9abeacc80c2de0b93 [1, 2]>
-
-Operations on two collections backed by different Redis servers will be performed in Python::
-
-    >>> list_1 = List((1, 2, 3), redis=StrictRedis(port=6379))
-    >>> list_2 = List((4, 5, 6), redis=StrictRedis(port=6380))
-    >>> list_1.extend(list_2)
-
-
-Synchronization
----------------
-Storing a mutable object like a ``list`` in a ``Dict`` or a ``Set`` can lead to surprising behavior.
-Because of Python semantics, it's impossible to automatically write to Redis when such an object is retrieved and modified.
-
-    >>> d = Dict({'key': [1, 2]})  # Store a mutable object
-    >>> d['key'].append(3)  # Retrieve and modify the object
-    >>> d['key']  # Retrieve the object from Redis again
-    [1, 2]
-
-To work with such objects you may use a ``Dict`` with ``writeback`` enabled.
-This will keep a local cache that is flushed to Redis when the ``sync`` method is called.
-
-    >>> d = Dict({'key': [1, 2]}, writeback=True)
-    >>> d['key'].append(3)
-    >>> d['key']  # Modifications are retrieved from the cache
-    [1, 2, 3]  
-    >>> d.sync()  # Flush cache to Redis
-
-You may also use a ``with`` block to automatically call the ``sync`` method.
-
-    >>> with Dict({'key': [1, 2]}) as d:
-    ...     d['key'].append(3)
-    >>> d['key']  # Changes were automatically synced
-    [1, 2, 3]
-
-The ``writeback`` option is automatically enabled for ``DefaultDict`` objects.
-
-Hashing dictionary keys and set elements
-----------------------------------------
-
-Python `takes care <https://docs.python.org/3/library/stdtypes.html#hashing-of-numeric-types>`_ to make sure that equal numeric values, such as ``1.0`` and ``1``, have the same hash value. If you add ``1.0`` to a ``set`` or a ``dict``, you will not be able to add ``1``, as an equal value is already stored.
-
-The Redis-backed ``Dict`` and ``Set`` classes in this library attempt to follow this behavior, but there are some differences. For the standard Python collections, you get back the first value you stored:
-
-    >>> python_dict = {}
-    >>> python_dict[1.0] = 'one'  # 1.0 stored first
-    >>> python_dict[1] = 'One'  # 1 stored second
-    >>> list(python_dict.keys())  # 1.0 is retrieved
-    [1.0]
-
-For the Redis-backed collections, you'll get back the integer:
-
-    >>> redis_dict = Dict()
-    >>> redis_dict[1.0] = 'one'  # 1.0 stored first
-    >>> redis_dict[1] = 'One'  # 1 stored second
-    >>> list(redis_dict.keys())  # 1 is retrieved
-    [1]
-
-This behavior applies to ``complex``, ``float``, ``Decimal``, and ``Fraction`` values that have an integer equivalent. It doesn't apply to values that don't have an integer equivalent (such as ``1.1`` or ``complex(1, 1)``).
-
-On Python 2 only, ``unicode`` types are converted to ``str`` types (with UTF-8 encoding) before being sent to Redis. ``str`` types are decoded to ``unicode`` types after being retrieved from Redis (if possible).
-
-Security considerations
+*   Persistent versions of the built-in Python :class:`dict`,
+    :class:`list`, and :class:`set` types that store their contents in Redis.
+*   Persistent versions of the :class:`defaultdict`, :class:`Counter`, and
+    :class:`deque` types from the `collections module
+    <https://docs.python.org/3/library/collections.html>`_ that store their
+    contents in Redis.
+*   Subclasses of several Python types whose instances can automatically or
+    manually back up their contents to Redis.
+*   Pythonic wrappers for Redis-specific data types such as `Sorted Sets`.
+    
+Narrative Documentation
 -----------------------
 
-Collections use :mod:`pickle`, which means you should never retrieve data from a source you don't trust.
+.. toctree::
+   :maxdepth: 2
 
-For example: suppose you maintain a web application that has user profiles.
-Users can submit their name, birthday, and a brief biography; and ultimately this is information stored in a Redis hash.
-*Do not* attach a ``redis_collection.Dict`` instance to that hash key - a user could construct a string that gives them the ability to execute arbitrary code with your Python process's privileges.
-
-Subclass customization
-----------------------
-
-Collections use :func:`uuid.uuid4` for generating unique keys.
-If you are not satisfied with that function's `collision probability <http://stackoverflow.com/a/786541/325365>`_ you may sublclass a collection and override its :func:`_create_key` method.
-
-If you don't like how  :mod:`pickle` does serialization, you may override the ``_pickle`` and ``_unpickle`` methods of the collection classes.
-Using other serializers may limit the objects you can store or retrieve.
-
-.. note::
-    On Python 2, the :mod:`pickle` module is used instead of the :mod:`cPickle` module.
-    This is intentional - see `issue #83 <https://github.com/honzajavorek/redis-collections/issues/83>`_.
-
-Philosophy
-----------
-
-*   All operations are atomic. Race conditions are bugs - please `report them <https://github.com/honzajavorek/redis-collections/issues>`_.
-
-*   Redis Collections stick to API of the original data structures known from Python standard library.
-    To have the same (expected) behaviour is considered to be more important than efficiency.
-
-    If there is more efficient approach than the one complying with the model interface, a new method exposing this approach should be introduced.
-
-    If a collection's behavior doesn't match its standard Python counterpart, please `create an issue <https://github.com/honzajavorek/redis-collections/issues>`_.
-
-*   Cases where different than standard approach would lead to better efficiency are mentioned and highlighted in API documentation as notes.
-    Known incompatibilities with the original API are marked as warnings.
-
-*   Behavior of **nested Redis Collections** containing other Redis Collections is **undefined**.
-    It is not recommended to create such structures. Use collection of keys instead.
-
-*   Redis Collections will take advantage of features in new versions of Redis, but will provide backports for older versions of Redis.
-
-    The earliest supported version of Redis is the one that ships with the oldest supported LTS release of Ubuntu Linux
-    (see `packages.ubuntu.com <http://packages.ubuntu.com/redis-server>`_).
+   basic-usage.rst
+   usage-notes.rst
+   development.rst
 
 API Documentation
 -----------------
 
-Redis Collections are composed of only several classes. All items listed below are exposed as public API, so you can (and you should) import them directly from ``redis_collections`` package.
+.. toctree::
+   :maxdepth: 2
 
-.. automodule:: redis_collections.base
+   api.rst
 
-.. autoclass:: RedisCollection
-    :members:
-    :special-members:
-    :exclude-members: __metaclass__, __weakref__
-
-.. automodule:: redis_collections.dicts
-
-.. autoclass:: Dict
-    :members:
-    :special-members:
-
-.. autoclass:: Counter
-    :members:
-    :special-members:
-
-.. autoclass:: DefaultDict
-    :members:
-    :special-members:
-
-.. automodule:: redis_collections.lists
-
-.. autoclass:: List
-    :members:
-    :special-members:
-
-.. autoclass:: Deque
-    :members:
-    :special-members:
-
-.. automodule:: redis_collections.sets
-
-.. autoclass:: Set
-    :members:
-    :special-members:
-
-.. automodule:: redis_collections.sortedsets
-
-.. autoclass:: SortedSetCounter
-    :members:
-    :special-members:
-
-.. automodule:: redis_collections.syncable
-    :members:
-
-Changelog
----------
-
-**→** :ref:`changelog`
-
-Maintainers
+Development
 -----------
 
-- Bo Bayles (`@bbayles <http://github.com/bbayles>`_)
-- Honza Javorek (`@honzajavorek <http://github.com/honzajavorek>`_)
+.. toctree::
+   :maxdepth: 2
 
-License: ISC
-------------
-
-© 2013-? Honza Javorek <mail@honzajavorek>
-
-This work is licensed under `ISC license <https://en.wikipedia.org/wiki/ISC_license>`_.
+   changelog.rst
+   development.rst    
 
 Indices and tables
 ------------------

--- a/docs/usage-notes.rst
+++ b/docs/usage-notes.rst
@@ -29,7 +29,7 @@ stored there previously:
 This should even work across processes, meaning if your Python script
 terminates, you can retrieve its data again from Redis.
 
-Each collection allows you to delete its Redis key with the `clear` method:
+Each collection allows you@ClaudiaKoerner  to delete its Redis key with the `clear` method:
 
 .. code-block:: python
 
@@ -63,7 +63,7 @@ connection as the original object:
     >>> list_02 = list_01.copy()  # result is using the same connection
 
 Operations on two collections backed by different Redis servers will be
-performed in Python::
+performed in Python:
 
 .. code-block:: python
 
@@ -176,30 +176,3 @@ serializers will limit the objects you can store or retrieve.
     On Python 2, the :mod:`pickle` module is used instead of the
     :mod:`cPickle` module. This is intentional - see
     `issue #83 <https://github.com/honzajavorek/redis-collections/issues/83>`_.
-
-
-
-Changelog
----------
-
-**→** :ref:`changelog`
-
-Maintainers
------------
-
-- Bo Bayles (`@bbayles <http://github.com/bbayles>`_)
-- Honza Javorek (`@honzajavorek <http://github.com/honzajavorek>`_)
-
-License: ISC
-------------
-
-© 2013-? Honza Javorek <mail@honzajavorek>
-
-This work is licensed under `ISC license <https://en.wikipedia.org/wiki/ISC_license>`_.
-
-Indices and tables
-------------------
-
-* :ref:`genindex`
-* :ref:`modindex`
-* :ref:`search`

--- a/docs/usage-notes.rst
+++ b/docs/usage-notes.rst
@@ -29,7 +29,7 @@ stored there previously:
 This should even work across processes, meaning if your Python script
 terminates, you can retrieve its data again from Redis.
 
-Each collection allows you@ClaudiaKoerner  to delete its Redis key with the `clear` method:
+Each collection allows you to delete its Redis key with the `clear` method:
 
 .. code-block:: python
 

--- a/docs/usage-notes.rst
+++ b/docs/usage-notes.rst
@@ -1,0 +1,205 @@
+.. _usage-notes:
+
+Usage notes
+=================
+
+Persistence
+-----------
+
+By default, a Redis key is generated when you create a new collection:
+
+.. code-block:: python
+
+    >>> from redis_collections import Dict
+
+    >>> D = Dict()
+    >>> D['answer'] = 42
+    >>> D.key
+    fe267c1dde5d4f648e7bac836a0168fe
+
+If you specify a key when creating a collection you can retrieve what was
+stored there previously:
+
+.. code-block:: python
+
+    >>> E = Dict(key='fe267c1dde5d4f648e7bac836a0168fe')
+    >>> E['answer']
+    42
+
+This should even work across processes, meaning if your Python script
+terminates, you can retrieve its data again from Redis.
+
+Each collection allows you to delete its Redis key with the `clear` method:
+
+.. code-block:: python
+
+    >>> D.clear()
+    >>> list(D.items())
+
+
+Redis connection
+----------------
+
+By default, collections create a new Redis connection when they are
+instantiated. This requires no configuration, but is inefficient if you are
+using multiple collections. To share a connection among multiple collections,
+create one (with ``redis.StrictRedis``) and pass it using the ``redis``
+keyword when creating the collections.
+
+.. code-block:: python
+
+    >>> from redis import StrictRedis
+    >>> conn = StrictRedis()
+    >>> D = Dict(redis=conn)
+    >>> L = List(redis=conn)
+
+A collection's ``copy`` method creates new a instance that uses the same Redis
+connection as the original object:
+
+.. code-block:: python
+
+    >>> conn = StrictRedis()
+    >>> list_01 = List([1, 2], redis=conn)
+    >>> list_02 = list_01.copy()  # result is using the same connection
+
+Operations on two collections backed by different Redis servers will be
+performed in Python::
+
+.. code-block:: python
+
+    >>> list_1 = List((1, 2, 3), redis=StrictRedis(port=6379))
+    >>> list_2 = List((4, 5, 6), redis=StrictRedis(port=6380))
+    >>> list_1.extend(list_2)
+
+
+Synchronization
+---------------
+Storing a mutable object like a ``list`` in a ``Dict`` or a ``List`` can lead
+to surprising behavior. Because of Python semantics, it's impossible to
+automatically write to Redis when such an object is retrieved and modified.
+
+.. code-block:: python
+
+    >>> D = Dict({'key': [1, 2]})  # Store a mutable object
+    >>> D['key'].append(3)  # Retrieve and modify the object
+    >>> D['key']  # Retrieve the object from Redis again
+    [1, 2]
+
+If you plan to work with mutable objects, be sure to specify ``writeback=True``
+when instantiating your collection. This will keep a local cache that is
+flushed to Redis when the ``sync`` method is called:
+
+.. code-block:: python
+
+    >>> D = Dict({'key': [1, 2]}, writeback=True)
+    >>> D['key'].append(3)
+    >>> D['key']  # Modifications are retrieved from the cache
+    [1, 2, 3]  
+    >>> D.sync()  # Flush cache to Redis
+
+You may also use a ``with`` block to automatically call the ``sync`` method.
+
+.. code-block:: python
+
+    >>> with Dict({'key': [1, 2]}) as D:
+    ...     D['key'].append(3)
+    >>> D['key']  # Changes were automatically synced
+    [1, 2, 3]
+
+The ``writeback`` option is automatically enabled for ``DefaultDict`` objects.
+
+Hashing dictionary keys and set elements
+----------------------------------------
+
+Python `takes care
+<https://docs.python.org/3/library/stdtypes.html#hashing-of-numeric-types>`_
+to make sure that equal numeric values, such as ``1.0`` and ``1``, have the
+same hash value. If you add ``1.0`` to a ``set`` or a ``dict``, you will not be
+able to add ``1``, as an equal value is already stored.
+
+The Redis-backed ``Dict`` and ``Set`` classes in this library attempt to follow
+this behavior, but there are some differences. For the built-in Python
+collections, you get back the first value you stored:
+
+.. code-block:: python
+
+    >>> python_dict = {}
+    >>> python_dict[1.0] = 'one'  # 1.0 stored first
+    >>> python_dict[1] = 'One'  # 1 stored second
+    >>> list(python_dict.keys())  # 1.0 is retrieved
+    [1.0]
+
+For the Redis-backed collections, you'll get back the integer:
+
+.. code-block:: python
+
+    >>> redis_dict = Dict()
+    >>> redis_dict[1.0] = 'one'  # 1.0 stored first
+    >>> redis_dict[1] = 'One'  # 1 stored second
+    >>> list(redis_dict.keys())  # 1 is retrieved
+    [1]
+
+This behavior applies to ``complex``, ``float``, ``Decimal``, and ``Fraction``
+values that have an integer equivalent. It doesn't apply to values that don't
+have an integer equivalent (such as ``1.1`` or ``complex(1, 1)``).
+
+On Python 2 only, ``unicode`` types are converted to ``str`` types
+(with UTF-8 encoding) before being sent to Redis. ``str`` types are decoded to
+``unicode`` types after being retrieved from Redis (if possible).
+
+Security considerations
+-----------------------
+
+Collections use :mod:`pickle`, which means you should never retrieve data from
+a source you don't trust.
+
+For example: suppose you maintain a web application that has user profiles.
+Users can submit their name, birthday, and a brief biography; and ultimately
+this is information stored in a Redis `hash`. *Do not* attach a
+``redis_collection.Dict`` instance to that hash key - a user could construct
+a string that gives them the ability to execute arbitrary code with your Python
+process's privileges.
+
+Subclass customization
+----------------------
+
+Collections use :func:`uuid.uuid4` for generating unique keys.
+If you are not satisfied with that function's
+`collision probability <http://stackoverflow.com/a/786541/325365>`_ you may
+sublclass a collection and override its :func:`_create_key` method.
+
+If you don't like how  :mod:`pickle` does serialization, you may override the
+``_pickle`` and ``_unpickle`` methods of the collection classes. Using other
+serializers will limit the objects you can store or retrieve.
+
+.. note::
+    On Python 2, the :mod:`pickle` module is used instead of the
+    :mod:`cPickle` module. This is intentional - see
+    `issue #83 <https://github.com/honzajavorek/redis-collections/issues/83>`_.
+
+
+
+Changelog
+---------
+
+**→** :ref:`changelog`
+
+Maintainers
+-----------
+
+- Bo Bayles (`@bbayles <http://github.com/bbayles>`_)
+- Honza Javorek (`@honzajavorek <http://github.com/honzajavorek>`_)
+
+License: ISC
+------------
+
+© 2013-? Honza Javorek <mail@honzajavorek>
+
+This work is licensed under `ISC license <https://en.wikipedia.org/wiki/ISC_license>`_.
+
+Indices and tables
+------------------
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`


### PR DESCRIPTION
This PR makes several changes to the documentation. See the results at [ReadTheDocs](http://redis-collections.readthedocs.io/en/docs-reorg/).

Summary:
* The contents of index.rst are split among multiple files now
* There is a new introduction and new "Installation and examples" section with more examples
* Several corrections to grammar and usage are made throughout