### PR TITLE
Add more information to GitHub README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,42 +9,81 @@ Redis Collections
    :target: https://coveralls.io/github/honzajavorek/redis-collections?branch=master
 
 
-Set of basic Python collections backed by Redis.
 
-Installation
-------------
+`redis-collections` is a Python library that provides a high-level
+interface to `Redis <http://redis.io/>`_, the excellent key-value store.
 
-.. code:: shell
+Quickstart
+----------
 
-   pip install redis-collections
+Install the library with ``pip install redis-collections``.
 
-Example
--------
+The standard collections (e.g. ``Dict``, ``List``, ``Set``) behave like their
+Python counterparts:
 
-Redis Collections provide a simple, Pythonic way to access Redis structures:
+.. code-block:: python
 
-.. code:: python
+    >>> from redis_collections import Dict, List, Set
+    
+    >>> D = Dict()
+    >>> D['answer'] = 42
+    >>> D['answer']
+    42
 
-  >>> from redis_collections import Dict
-  >>> d = Dict()
-  >>> d['answer'] = 42
-  >>> d
-  <redis_collections.Dict at fe267c1dde5d4f648e7bac836a0168fe {'answer': 42}>
-  >>> d.items()
-  [('answer', 42)]
-  >>> d.update({'hasek': 39, 'jagr': 68})
-  >>> d
-  <redis_collections.Dict at fe267c1dde5d4f648e7bac836a0168fe {'answer': 42, 'jagr': 68, 'hasek': 39}>
-  >>> del d['answer']
-  >>> d
-  <redis_collections.Dict at fe267c1dde5d4f648e7bac836a0168fe {'jagr': 68, 'hasek': 39}>
+The syncable collections in this package provide types whose
+contents are kept in memory. When their ``sync`` method is called those
+contents are written to Redis:
 
-Available collections are ``Dict``, ``List``, ``Set``, ``Counter``, and ``DefaultDict``.
+.. code-block:: python
+
+    >>> from redis_collections import SyncableDict
+    
+    >>> with SyncableDict() as D:
+    ...     D['a'] = 1  # No write to Redis
+    ...     D['a'] += 1  # No read from or write to Redis
+    >>> D['a']  # D.sync() is called at the end of the with block
+    2
+
+Available collections
+---------------------
+
+The library provides the collections described below. Import them from ``redis_collections``:
+
++---------------------+------------+-------------------------+----------------------------------------------------------+
+| Collection          | Redis type | Operations in           | Description                                              |
++=====================+============+=========================+==========================================================+
+| Dict                | Hash       | Redis                   | Emulates Python's ``dict``                               |
++---------------------+------------+-------------------------+----------------------------------------------------------+
+| List                | List       | Redis                   | Emulates Python's ``list``                               |
++---------------------+------------+-------------------------+----------------------------------------------------------+
+| Set                 | Set        | Redis                   | Emulates Python's ``set``                                |
++---------------------+------------+-------------------------+----------------------------------------------------------+
+| Counter             | Hash       | Redis                   | Emulates Python's ``collections.Counter``                |
++---------------------+------------+-------------------------+----------------------------------------------------------+
+| DefaultDict         | Hash       | Redis                   | Emulates Python's ``collections.defaultdict``            |
++---------------------+------------+-------------------------+----------------------------------------------------------+
+| Deque               | List       | Redis                   | Emulates Python's ``collections.deque``                  |
++---------------------+------------+-------------------------+----------------------------------------------------------+
+| LRUDict             | Hash       | Python                  | LRU algorithm pushes items from Python to Redis          |
++---------------------+------------+-------------------------+----------------------------------------------------------+
+| SyncableDict        | Hash       | Python                  | ``dict`` subclass that syncs to Redis                    |
++---------------------+------------+-------------------------+----------------------------------------------------------+
+| SyncableList        | List       | Python                  | ``list`` subclass that syncs to Redis                    |
++---------------------+------------+-------------------------+----------------------------------------------------------+
+| SyncableSet         | Set        | Python                  | ``set`` subclass that syncs to Redis                     |
++---------------------+------------+-------------------------+----------------------------------------------------------+
+| SyncableCounter     | Hash       | Python                  | ``collections.Counter`` subclass that syncs to Redis     |
++---------------------+------------+-------------------------+----------------------------------------------------------+
+| SyncableDefaultDict | Hash       | Python                  | ``collections.defaultdict`` subclass that syncs to Redis |
++---------------------+------------+-------------------------+----------------------------------------------------------+
+| SortedSetCounter    | Sorted Set | Redis                   | Restricted interface for Redis's Sorted Set              |
++---------------------+------------+-------------------------+----------------------------------------------------------+
 
 Documentation
 -------------
 
-**→** `redis-collections.readthedocs.io <https://redis-collections.readthedocs.io/>`_
+For more information, see
+`redis-collections.readthedocs.io <https://redis-collections.readthedocs.io/>`_
 
 Maintainers
 -----------

--- a/README.rst
+++ b/README.rst
@@ -17,6 +17,10 @@ Quickstart
 ----------
 
 Install the library with ``pip install redis-collections``.
+Import the collections from the top-level ``redis_collections`` package.
+
+Standard collections
+^^^^^^^^^^^^^^^^^^^^
 
 The standard collections (e.g. ``Dict``, ``List``, ``Set``) behave like their
 Python counterparts:
@@ -29,6 +33,25 @@ Python counterparts:
     >>> D['answer'] = 42
     >>> D['answer']
     42
+
++---------------------+------------+------------------------------------------------------+
+|  Collection         | Redis type | Description                                          |
++=====================+============+======================================================+
+| ``Dict``            | Hash       | Emulates Python's ``dict``                           |
++---------------------+------------+------------------------------------------------------+
+| ``List``            | List       | Emulates Python's ``list``                           |
++---------------------+------------+------------------------------------------------------+
+| ``Set``             | Set        | Emulates Python's ``set``                            |
++---------------------+------------+------------------------------------------------------+
+| ``Counter``         | Hash       | Emulates Python's ``collections.Counter``            |
++---------------------+------------+------------------------------------------------------+
+| ``DefaultDict``     | Hash       | Emulates Python's ``collections.defaultdict``        |
++---------------------+------------+------------------------------------------------------+
+| ``Deque``           | List       | Emulates Python's ``collections.deque``              |
++---------------------+------------+------------------------------------------------------+
+
+Syncable collections
+^^^^^^^^^^^^^^^^^^^^
 
 The syncable collections in this package provide types whose
 contents are kept in memory. When their ``sync`` method is called those
@@ -44,40 +67,51 @@ contents are written to Redis:
     >>> D['a']  # D.sync() is called at the end of the with block
     2
 
-Available collections
----------------------
++-------------------------+-----------------------------+-----------------------+
+| Collection              | Python type                 | Description           |
++=========================+=============================+=======================+
+| ``SyncableDict``        | ``dict``                    | Syncs to a Redis Hash |
++-------------------------+-----------------------------+-----------------------+
+| ``SyncableList``        | ``list``                    | Syncs to a Redis List |
++-------------------------+-----------------------------+-----------------------+
+| ``SyncableSet``         | ``set``                     | Syncs to a Redis Set  |
++-------------------------+-----------------------------+-----------------------+
+| ``SyncableCounter``     | ``collections.Counter``     | Syncs to a Redis Hash |
++-------------------------+-----------------------------+-----------------------+
+| ``SyncableDefaultDict`` | ``collections.defaultdict`` | Syncs to a Redis Hash |
++-------------------------+-----------------------------+-----------------------+
 
-The library provides the collections described below. Import them from ``redis_collections``:
+Other collections
+^^^^^^^^^^^^^^^^^
 
-+---------------------+------------+-------------------------+----------------------------------------------------------+
-| Collection          | Redis type | Operations in           | Description                                              |
-+=====================+============+=========================+==========================================================+
-| Dict                | Hash       | Redis                   | Emulates Python's ``dict``                               |
-+---------------------+------------+-------------------------+----------------------------------------------------------+
-| List                | List       | Redis                   | Emulates Python's ``list``                               |
-+---------------------+------------+-------------------------+----------------------------------------------------------+
-| Set                 | Set        | Redis                   | Emulates Python's ``set``                                |
-+---------------------+------------+-------------------------+----------------------------------------------------------+
-| Counter             | Hash       | Redis                   | Emulates Python's ``collections.Counter``                |
-+---------------------+------------+-------------------------+----------------------------------------------------------+
-| DefaultDict         | Hash       | Redis                   | Emulates Python's ``collections.defaultdict``            |
-+---------------------+------------+-------------------------+----------------------------------------------------------+
-| Deque               | List       | Redis                   | Emulates Python's ``collections.deque``                  |
-+---------------------+------------+-------------------------+----------------------------------------------------------+
-| LRUDict             | Hash       | Python                  | LRU algorithm pushes items from Python to Redis          |
-+---------------------+------------+-------------------------+----------------------------------------------------------+
-| SyncableDict        | Hash       | Python                  | ``dict`` subclass that syncs to Redis                    |
-+---------------------+------------+-------------------------+----------------------------------------------------------+
-| SyncableList        | List       | Python                  | ``list`` subclass that syncs to Redis                    |
-+---------------------+------------+-------------------------+----------------------------------------------------------+
-| SyncableSet         | Set        | Python                  | ``set`` subclass that syncs to Redis                     |
-+---------------------+------------+-------------------------+----------------------------------------------------------+
-| SyncableCounter     | Hash       | Python                  | ``collections.Counter`` subclass that syncs to Redis     |
-+---------------------+------------+-------------------------+----------------------------------------------------------+
-| SyncableDefaultDict | Hash       | Python                  | ``collections.defaultdict`` subclass that syncs to Redis |
-+---------------------+------------+-------------------------+----------------------------------------------------------+
-| SortedSetCounter    | Sorted Set | Redis                   | Restricted interface for Redis's Sorted Set              |
-+---------------------+------------+-------------------------+----------------------------------------------------------+
+The ``LRUDict`` collection stores recently used items in in memory.
+It pushes older items to Redis:
+
+.. code-block:: python
+
+    >>> from redis_collections import LRUDict
+
+    >>> D = LRUDict(maxsize=2)
+    >>> D['a'] = 1
+    >>> D['b'] = 2
+    >>> D['c'] = 2  # 'a' is pushed to Redis and 'c' is stored locally
+    >>> D['a']  # 'b' is pushed to Redis and 'a' is retrieved for local storage 
+    1
+    >>> D.sync()  # All items are copied to Redis
+
+The ``SortedSetCounter`` provides access to the Redis
+`Sorted Set <http://redis.io/topics/data-types#sorted-sets>`_ type:
+
+.. code-block:: python
+
+    >>> from redis_collections import SortedSetCounter
+
+    >>> ssc = SortedSetCounter([('earth', 300), ('mercury', 100)])
+    >>> ssc.set_score('venus', 200)
+    >>> ssc.get_score('venus')
+    200.0
+    >>> ssc.items()
+    [('mercury', 100.0), ('venus', 200.0), ('earth', 300.0)]
 
 Documentation
 -------------


### PR DESCRIPTION
This PR changes README.rst to have a reference to the various collections, consistent with the newly-reorganized docs (#89).