### PR TITLE
0.3.2 release for List equality testing bug fix

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -50,3 +50,13 @@ New features in 0.3.x
 - `Deque <https://github.com/honzajavorek/redis-collections/issues/6>`_ was added.
 
 See the `Github milestone <https://github.com/honzajavorek/redis-collections/milestone/1>`_ for more details.
+
+
+Bug fixes in 0.3.x
+------------------
+
+- 0.3.1 fixes a potential problem with inconsistent hashing in ``Dict`` and ``Set``.
+  See `issue 83 <https://github.com/honzajavorek/redis-collections/issues/83>`_
+
+- 0.3.2 fixes a problem with equality testing for ``List``.
+  Two lists that started out the same but ended differently could compare as ``True``.

--- a/redis_collections/__init__.py
+++ b/redis_collections/__init__.py
@@ -2,7 +2,7 @@
 from __future__ import division, print_function, unicode_literals
 
 __title__ = 'redis-collections'
-__version__ = '0.3.1'
+__version__ = '0.3.2'
 __author__ = 'Honza Javorek'
 __license__ = 'ISC'
 __copyright__ = 'Copyright 2013-? Honza Javorek'

--- a/redis_collections/lists.py
+++ b/redis_collections/lists.py
@@ -590,7 +590,18 @@ class List(RedisCollection, collections.MutableSequence):
 
         def eq_trans(pipe):
             self_values = self.__iter__(pipe)
-            other_values = other.__iter__(pipe) if use_redis else other
+            self_len = self.__len__(pipe)
+
+            if use_redis:
+                other_values = other.__iter__(pipe)
+                other_len = other.__len__(pipe)
+            else:
+                other_values = other
+                other_len = len(other)
+
+            if self_len != other_len:
+                return False
+
             for v_self, v_other in six.moves.zip(self_values, other_values):
                 if v_self != v_other:
                     return False

--- a/tests/test_lists.py
+++ b/tests/test_lists.py
@@ -45,8 +45,22 @@ class ListTest(RedisTestCase):
         data = (0, 1, 2, 3)
         for init in (self.create_list, list):
             L = init(data)
+
+            # Correct type, correct values
             self.assertTrue(L == list(data))
             self.assertTrue(list(data) == L)
+
+            # Correct type, wrong values
+            wrong_data = [0, 1, 2]
+            self.assertFalse(L == wrong_data)
+            self.assertFalse(wrong_data == L)
+
+            # Correct type, wrong values
+            wrong_data = [0, 1, 2, 3, 4]
+            self.assertFalse(L == wrong_data)
+            self.assertFalse(wrong_data == L)
+
+            # Wrong type (data is tuple)
             self.assertFalse(L == data)
             self.assertFalse(data == L)
 


### PR DESCRIPTION
This PR fixes a bug with `List.__eq__`. That method should check the lengths of the two lists, but doesn't, meaning that two lists like `[0, 1, 2]` and `[0, 1, 2, 3]` will compare as equal.

I will release this version to PyPI shortly.