### PR TITLE
Test coverage update

### DIFF
--- a/redis_collections/base.py
+++ b/redis_collections/base.py
@@ -241,8 +241,13 @@ class RedisCollection(object):
     def sync(self):
         pass
 
+    @abc.abstractmethod
     def _repr_data(self):
-        return None
+        """
+        Abstract method for subclasses to implement.
+        Return a string appropriate for displaying the contents of the
+        collection. Called by __repr__.
+        """
 
     def __repr__(self):
         cls_name = self.__class__.__name__

--- a/redis_collections/dicts.py
+++ b/redis_collections/dicts.py
@@ -38,7 +38,9 @@ class Dict(RedisCollection, collections.MutableMapping):
 
     class __missing_value(object):
         def __repr__(self):
-            return '<missing value>'  # for purposes of generated documentation
+            # Specified here so that the documentation shows a useful string
+            # for methods that take __marker as a keyword argument
+            return '<missing value>'
     __marker = __missing_value()
 
     def __init__(self, *args, **kwargs):
@@ -440,7 +442,7 @@ class Counter(Dict):
             if isinstance(other, Dict):
                 data.update(other.iteritems(pipe))
             elif isinstance(other, RedisCollection):
-                data.update(other.__iter__(pipe))
+                data.update(collections.Counter(other.__iter__(pipe)))
             else:
                 data.update(other)
 
@@ -516,8 +518,6 @@ class Counter(Dict):
                 other_counter = collections.Counter(
                     {k: v for k, v in other.iteritems(pipe=pipe)}
                 )
-            elif isinstance(other, RedisCollection):
-                other_counter = collections.Counter(other.__iter__(pipe))
             else:
                 other_counter = other
 

--- a/redis_collections/lists.py
+++ b/redis_collections/lists.py
@@ -547,7 +547,18 @@ class List(RedisCollection, collections.MutableSequence):
 
         def eq_trans(pipe):
             self_values = self.__iter__(pipe)
-            other_values = other.__iter__(pipe) if use_redis else other
+            self_len = self.__len__(pipe)
+
+            if use_redis:
+                other_values = other.__iter__(pipe)
+                other_len = other.__len__(pipe)
+            else:
+                other_values = other
+                other_len = len(other)
+
+            if self_len != other_len:
+                return False
+
             for v_self, v_other in six.moves.zip(self_values, other_values):
                 if v_self != v_other:
                     return False

--- a/tests/test_lists.py
+++ b/tests/test_lists.py
@@ -45,8 +45,22 @@ class ListTest(RedisTestCase):
         data = (0, 1, 2, 3)
         for init in (self.create_list, list):
             L = init(data)
+
+            # Correct type, correct values
             self.assertTrue(L == list(data))
             self.assertTrue(list(data) == L)
+
+            # Correct type, wrong values
+            wrong_data = [0, 1, 2]
+            self.assertFalse(L == wrong_data)
+            self.assertFalse(wrong_data == L)
+
+            # Correct type, wrong values
+            wrong_data = [0, 1, 2, 3, 4]
+            self.assertFalse(L == wrong_data)
+            self.assertFalse(wrong_data == L)
+
+            # Wrong type (data is tuple)
             self.assertFalse(L == data)
             self.assertFalse(data == L)
 

--- a/tests/test_lists.py
+++ b/tests/test_lists.py
@@ -46,21 +46,27 @@ class ListTest(RedisTestCase):
         for init in (self.create_list, list):
             L = init(data)
 
-            # Correct type, correct values
+            # Correct type, correct values -> equal
             self.assertTrue(L == list(data))
             self.assertTrue(list(data) == L)
 
-            # Correct type, wrong values
+            self.assertTrue(L == self.create_list(data))
+            self.assertTrue(self.create_list(data) == L)
+
+            # Correct type, wrong values -> not equal
             wrong_data = [0, 1, 2]
             self.assertFalse(L == wrong_data)
             self.assertFalse(wrong_data == L)
 
-            # Correct type, wrong values
+            wrong_data = [0, 1, 2, '4']
+            self.assertFalse(L == wrong_data)
+            self.assertFalse(wrong_data == L)
+
             wrong_data = [0, 1, 2, 3, 4]
             self.assertFalse(L == wrong_data)
             self.assertFalse(wrong_data == L)
 
-            # Wrong type (data is tuple)
+            # Wrong type, correct values -> not equal
             self.assertFalse(L == data)
             self.assertFalse(data == L)
 

--- a/tests/test_sets.py
+++ b/tests/test_sets.py
@@ -7,7 +7,7 @@ from fractions import Fraction
 import unittest
 import sys
 
-from redis_collections import Set
+from redis_collections import List, Set
 
 from .base import RedisTestCase
 
@@ -63,10 +63,12 @@ class SetTest(RedisTestCase):
             s_2 = init([4, 5])
             s_3 = {3, 4, 5}
             s_4 = [4, 5]
+            s_5 = List([4, 5], redis=self.redis)
 
             self.assertTrue(s_1.isdisjoint(s_2))
             self.assertFalse(s_1.isdisjoint(s_3))
             self.assertTrue(s_1.isdisjoint(s_4))
+            self.assertTrue(s_1.isdisjoint(s_5))
             self.assertRaises(TypeError, s_1.isdisjoint, None)
 
     def test_eq_le_lt_issubset(self):
@@ -77,6 +79,7 @@ class SetTest(RedisTestCase):
             s_4 = {1, 2}
             s_5 = [1, 2, 3, 4]
             s_6 = self.create_set([1, 2, 3, 4])
+            s_7 = List([1, 2, 3, 4], redis=self.redis)
 
             self.assertTrue(s_1.issubset(s_2))
             self.assertFalse(s_1 == s_2)
@@ -103,6 +106,8 @@ class SetTest(RedisTestCase):
             self.assertTrue(s_2 == s_6)
             self.assertTrue(s_6 == s_6)
 
+            self.assertTrue(s_2.issubset(s_7))
+
     def test_superset(self):
         for init in (self.create_set, set):
             s_1 = init([1, 2, 3, 4])
@@ -111,6 +116,7 @@ class SetTest(RedisTestCase):
             s_4 = {1, 2}
             s_5 = {1, 2, 3, 4}
             s_6 = [1, 2]
+            s_7 = List([1, 2], redis=self.redis)
 
             self.assertTrue(s_1.issuperset(s_2))
             self.assertTrue(s_1 >= s_2)
@@ -131,6 +137,8 @@ class SetTest(RedisTestCase):
             self.assertTrue(s_1.issuperset(s_6))
             if PYTHON_VERSION >= (3, 4):
                 self.assertRaises(TypeError, lambda: s_1 >= s_6)
+
+            self.assertTrue(s_1.issuperset(s_7))
 
             self.assertRaises(TypeError, s_1.issuperset, None)
 
@@ -159,6 +167,7 @@ class SetTest(RedisTestCase):
             s_2 = init([2, 3, 4])
             s_3 = {2, 3, 4}
             s_4 = [2, 3, 4]
+            s_5 = List([2, 3, 4], redis=self.redis)
 
             self.assertEqual(sorted(s_1.intersection(s_2)), [2, 3])
             self.assertEqual(sorted(s_1 & s_2), [2, 3])
@@ -170,6 +179,8 @@ class SetTest(RedisTestCase):
 
             self.assertEqual(sorted(s_1.intersection(s_4)), [2, 3])
             self.assertRaises(TypeError, lambda: s_1 & s_4)
+
+            self.assertEqual(sorted(s_1.intersection(s_5)), [2, 3])
 
     def test_difference(self):
         for init in (self.create_set, set):
@@ -195,6 +206,7 @@ class SetTest(RedisTestCase):
             s_2 = init([3, 4, 5, 6])
             s_3 = {3, 4, 5, 6}
             s_4 = [3, 4, 5, 6]
+            s_5 = List([3, 4, 5, 6], redis=self.redis)
 
             self.assertEqual(
                 sorted(s_1.symmetric_difference(s_2)), [1, 2, 5, 6]
@@ -213,6 +225,10 @@ class SetTest(RedisTestCase):
                 sorted(s_1.symmetric_difference(s_4)), [1, 2, 5, 6]
             )
             self.assertRaises(TypeError, lambda: s_1 ^ s_4)
+
+            self.assertEqual(
+                sorted(s_1.symmetric_difference(s_5)), [1, 2, 5, 6]
+            )
 
     def test_copy(self):
         for init in (self.create_set, set):

--- a/tests/test_sets.py
+++ b/tests/test_sets.py
@@ -437,6 +437,12 @@ class SetTest(RedisTestCase):
 
         self.assertIn("{1}", repr(redis_set))
 
+    def test_sync(self):
+        # sync is a no-op for Set, but it shouldn't cause an error
+        redis_set = self.create_set()
+        redis_set.add(1)
+        redis_set.sync()
+
 
 class _Set(Set):
     pass


### PR DESCRIPTION
This PR brings in the fix from #91 (``List`` equality testing bug) and raises test coverage to [100%](https://coveralls.io/builds/8043327).

Most of the missing tests were related to mixing standard collection types (e.g. update a `Dict` with a `List`). I will leave some comments about non-test changes.