### PR TITLE
Updates to API Documentation

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -7,12 +7,16 @@ Redis Collections are composed of only several classes. All items listed below
 are exposed as public API, so you can (and you should) import them directly
 from ``redis_collections`` package.
 
+----
+
 .. automodule:: redis_collections.base
 
 .. autoclass:: RedisCollection
     :members:
     :special-members:
     :exclude-members: __metaclass__, __weakref__
+
+----
 
 .. automodule:: redis_collections.dicts
 
@@ -28,6 +32,8 @@ from ``redis_collections`` package.
     :members:
     :special-members:
 
+----
+
 .. automodule:: redis_collections.lists
 
 .. autoclass:: List
@@ -38,17 +44,23 @@ from ``redis_collections`` package.
     :members:
     :special-members:
 
+----
+
 .. automodule:: redis_collections.sets
 
 .. autoclass:: Set
     :members:
     :special-members:
 
+----
+
 .. automodule:: redis_collections.sortedsets
 
 .. autoclass:: SortedSetCounter
     :members:
     :special-members:
+
+----
 
 .. automodule:: redis_collections.syncable
     :members:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -97,7 +97,7 @@ pygments_style = 'sphinx'
 
 # This value selects if automatically documented members are sorted
 # alphabetical.
-autodoc_member_order = 'groupwise'
+autodoc_member_order = 'bysource'
 
 
 # -- Options for HTML output ---------------------------------------------------

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -1,4 +1,4 @@
-.. _usage-notes:
+.. development:
 
 Development
 ===========

--- a/docs/usage-notes.rst
+++ b/docs/usage-notes.rst
@@ -71,6 +71,7 @@ performed in Python:
     >>> list_2 = List((4, 5, 6), redis=StrictRedis(port=6380))
     >>> list_1.extend(list_2)
 
+.. _Synchronization:
 
 Synchronization
 ---------------
@@ -94,7 +95,7 @@ flushed to Redis when the ``sync`` method is called:
     >>> D = Dict({'key': [1, 2]}, writeback=True)
     >>> D['key'].append(3)
     >>> D['key']  # Modifications are retrieved from the cache
-    [1, 2, 3]  
+    [1, 2, 3]
     >>> D.sync()  # Flush cache to Redis
 
 You may also use a ``with`` block to automatically call the ``sync`` method.
@@ -107,6 +108,8 @@ You may also use a ``with`` block to automatically call the ``sync`` method.
     [1, 2, 3]
 
 The ``writeback`` option is automatically enabled for ``DefaultDict`` objects.
+
+.. _Hashing:
 
 Hashing dictionary keys and set elements
 ----------------------------------------

--- a/redis_collections/dicts.py
+++ b/redis_collections/dicts.py
@@ -14,8 +14,9 @@ Each collection stores its items in a Redis
     in a collection, be sure to enable ``writeback``.
     See :ref:`Synchronization` for more information.
 
-    When storing numeric types (e.g. :class:`float`) as keys, be aware that these
-    collections behave slightly differently from standard Python dictionaries.
+    When storing numeric types (e.g. :class:`float`) as keys, be aware that
+    these collections behave slightly differently from standard Python
+    dictionaries.
     See :ref:`Hashing` for more information.
 
 """
@@ -401,41 +402,49 @@ class Dict(RedisCollection, collections.MutableMapping):
 
 
 class Counter(Dict):
-    """Mutable **mapping** collection aiming to have the same API as
-    :class:`collections.Counter`. See `Counter
+    """
+    Collection based on the Python standard library's
+    :class:`collections.Counter` type.
+    Items are stored in a Redis hash structure.
+    See Python's `Counter documentation
     <http://docs.python.org/2/library/collections.html#collections.Counter>`_
-    for further details. The Redis implementation is based on the
-    `hash <http://redis.io/commands#hash>`_ type.
+    for usage notes.
 
-    .. warning::
-        Not available in Python 2.6.
-
-    .. warning::
-        Note that this :class:`Counter` does not implement
-        methods :func:`viewitems`, :func:`viewkeys`, and :func:`viewvalues`,
-        which are available in Python 2.7's version.
+    The :func:`viewitems`, :func:`viewkeys`, and :func:`viewvalues` methods
+    from Python 2.7's Counter type are not implemented.
     """
 
     def __init__(self, *args, **kwargs):
-        """Breakes the original :class:`Counter` API, because there is no
-        support for keyword syntax. The only single way to create
-        :class:`Counter` object is to pass iterable or mapping as the first
-        argument. Iterable is expected to be a sequence of elements,
-        not a sequence of ``(key, value)`` pairs.
+        """
+        Create a new Counter object.
+
+        If the first argument (*data*) is another mapping type, create the new
+        Counter with the counts of the input items as the initial data.
+        Or, If the first argument is an iterable of ``(key, value)`` pairs,
+        create the new Counter with those items as the initial data.
+
+        Unlike Python's standard :class:`collections.Counter` type,
+        initial items cannot be set using keyword arguments.
+        Keyword arguments are passed to the :class:`RedisCollection`
+        constructor.
 
         :param data: Initial data.
         :type data: iterable or mapping
+
         :param redis: Redis client instance. If not provided, default Redis
                       connection is used.
         :type redis: :class:`redis.StrictRedis`
+
         :param key: Redis key for the collection. Collections with the same key
                     point to the same data. If not provided, a random
                     string is generated.
         :type key: str
 
-        .. warning::
-            As mentioned, :class:`Counter` does not support following
-            initialization syntax: ``c = Counter(a=1, b=2)``
+        :param writeback: If ``True``, keep a local cache of changes for
+                          storing modifications to mutable values. Changes will
+                          be written to Redis after calling the ``sync``
+                          method.
+        :type writeback: bool
         """
         super(Counter, self).__init__(*args, **kwargs)
 

--- a/redis_collections/dicts.py
+++ b/redis_collections/dicts.py
@@ -665,7 +665,7 @@ class DefaultDict(Dict):
 
     def __init__(self, *args, **kwargs):
         """
-        Create a new defaultdict object.
+        Create a new DefaultDict object.
 
         The first argument provides the initial value for the
         ``default_factory`` attribute; it defaults to ``None``.

--- a/redis_collections/dicts.py
+++ b/redis_collections/dicts.py
@@ -367,6 +367,11 @@ class Dict(RedisCollection, collections.MutableMapping):
             self._update_helper(kwargs)
 
     def copy(self, key=None):
+        """
+        Return a new collection with the same items as this one.
+        If *key* is specified, create the new collection with the given
+        Redis key.
+        """
         other = self.__class__(redis=self.redis, key=key)
         other.update(self)
 
@@ -410,6 +415,9 @@ class Counter(Dict):
     See Python's `Counter documentation
     <http://docs.python.org/2/library/collections.html#collections.Counter>`_
     for usage notes.
+
+    Counter inherits from Dict, so see its API documentation for information
+    on other methods.
 
     The :func:`viewitems`, :func:`viewkeys`, and :func:`viewvalues` methods
     from Python 2.7's Counter type are not implemented.
@@ -648,6 +656,9 @@ class DefaultDict(Dict):
     <https://docs.python.org/3/library/collections.html#collections.defaultdict>`_
     for usage notes.
 
+    DefaultDict inherits from Dict, so see its API documentation for
+    information on other methods.
+
     The :func:`viewitems`, :func:`viewkeys`, and :func:`viewvalues` methods
     from Python 2.7's Counter type are not implemented.
     """
@@ -702,6 +713,11 @@ class DefaultDict(Dict):
         return value
 
     def copy(self, key=None):
+        """
+        Return a new collection with the same items as this one.
+        If *key* is specified, create the new collection with the given
+        Redis key.
+        """
         other = self.__class__(self.default_factory, redis=self.redis, key=key)
         other.update(self)
 

--- a/redis_collections/dicts.py
+++ b/redis_collections/dicts.py
@@ -140,7 +140,8 @@ class Dict(RedisCollection, collections.MutableMapping):
         be :obj:`None`.
 
         .. note::
-        This method is not implemented by standard Python dictionary classes.
+            This method is not implemented by standard Python dictionary
+            classes.
         """
         pickled_keys = (self._pickle_key(k) for k in keys)
         pickled_values = self.redis.hmget(self.key, *pickled_keys)
@@ -639,23 +640,30 @@ class Counter(Dict):
 
 
 class DefaultDict(Dict):
-    """Mutable **mapping** collection aiming to have the same API as
-    :class:`collections.defaultdict`. See
-    `defaultdict  <https://docs.python.org/2/library/collections.html>`_ for
-    further details. The Redis implementation is based on the
-    `hash <http://redis.io/commands#hash>`_ type.
+    """
+    Collection based on the Python standard library's
+    :class:`collections.defaultdict` type.
+    Items are stored in a Redis hash structure.
+    See Python's `defaultdict documentation
+    <https://docs.python.org/3/library/collections.html#collections.defaultdict>`_
+    for usage notes.
 
-    .. warning::
-        Note that this :class:`DefaultDict` does not implement
-        methods :func:`viewitems`, :func:`viewkeys`, and :func:`viewvalues`,
-        which are available in Python 2.7's version.
+    The :func:`viewitems`, :func:`viewkeys`, and :func:`viewvalues` methods
+    from Python 2.7's Counter type are not implemented.
     """
 
     def __init__(self, *args, **kwargs):
-        """Breakes the original :class:`defaultdict` API, because there is no
-        support for keyword syntax. The only single way to create
-        :class:`defaultdict` object is to pass an iterable or mapping as the
-        second argument.
+        """
+        Create a new defaultdict object.
+
+        The first argument provides the initial value for the
+        ``default_factory`` attribute; it defaults to ``None``.
+        All other arguments are passed to the ``Dict`` constructor.
+
+        Unlike Python's standard :class:`collections.defaultdict` type,
+        initial items cannot be set using keyword arguments.
+        Keyword arguments are passed to the :class:`RedisCollection`
+        constructor via the ``Dict`` constructor.
 
         :param default_factory: Used to provide default values for missing
                                 keys.
@@ -669,10 +677,6 @@ class DefaultDict(Dict):
                     point to the same data. If not provided, a random
                     string is generated.
         :type key: str
-
-        .. warning::
-            As mentioned, :class:`DefaultDict` does not support following
-            initialization syntax: ``d = DefaultDict(None, a=1, b=2)``
         """
         kwargs.setdefault('writeback', True)
         if args:

--- a/redis_collections/lists.py
+++ b/redis_collections/lists.py
@@ -640,17 +640,35 @@ class List(RedisCollection, collections.MutableSequence):
 
 
 class Deque(List):
-    """A Redis-backed version of Python's :class:`collections.deque`.
+    """
+    Collection based on the Python standard library's
+    :class:`collections.deque` type.
+    Items are stored in a Redis hash structure.
     See Python's `deque documentation
     <https://docs.python.org/3/library/collections.html#collections.deque>`_
-    for more details. The Redis implementation is based on the `list type
-    <http://redis.io/commands#list>`_.
-    """
+    for usage notes.
 
+    Dequq inherits from List, so see its API documentation for
+    information on other methods.
+    """
     _python_cls = collections.deque
 
     def __init__(self, *args, **kwargs):
         """
+        Create a new Deque object.
+
+        If the first argument (*data*) is an iterable object, create the new
+        Deque with its values as the initial data.
+
+        If the second argument (*maxlen*) is an integer, create the Deque with
+        the given maximum length.
+        If the second argument is not given or is ``None``, create the Deque
+        without a maximum length.
+
+        If the Deque is full (the number of values stored is equal to the
+        maximum length), adding new items to one side will cause a
+        corresponding number of items to be removed from the other side.
+
         :param data: Initial data.
         :type data: iterable
         :param maxlen: Maximum size.
@@ -761,8 +779,9 @@ class Deque(List):
 
     def copy(self, key=None):
         """
-        Return a new :obj:`Deque` with the specified *key*. The new collection
-        will have the same values and maxlen as this collection.
+        Return a new collection with the same items as this one.
+        If *key* is specified, create the new collection with the given
+        Redis key.
         """
         other = self.__class__(
             self.__iter__(),
@@ -811,8 +830,9 @@ class Deque(List):
 
     def insert(self, index, value):
         """
-        Insert *value* into the collection at *index*. If the insertion would
-        the collection to grow beyond ``maxlen``, raise ``IndexError``.
+        Insert *value* into the collection at *index*.
+        If the insertion would the collection to grow beyond ``maxlen``,
+        raise ``IndexError``.
         """
         def insert_trans(pipe):
             len_self = self.__len__(pipe)
@@ -840,8 +860,8 @@ class Deque(List):
 
     def rotate(self, n=1):
         """
-        Rotate the deque n steps to the right. If n is negative, rotate to the
-        left.
+        Rotate the deque n steps to the right.
+        If n is negative, rotate to the left.
         """
         # No work to do for a 0-step rotate
         if n == 0:

--- a/redis_collections/lists.py
+++ b/redis_collections/lists.py
@@ -3,7 +3,15 @@
 lists
 ~~~~~
 
-Collections based on the list interface.
+The `lists` module contains standard collections based on Python lists.
+Included collections are :class:`List` and :class:`Deque`.
+Each collection stores its values in a Redis
+`list <http://redis.io/commands#list>`_ structure.
+
+.. note::
+    If you need to store mutable values like :class:`list`\s or :class:`set`\s
+    in a collection, be sure to enable ``writeback``.
+    See :ref:`Synchronization` for more information.
 """
 from __future__ import division, print_function, unicode_literals
 
@@ -18,16 +26,21 @@ from .base import RedisCollection
 
 
 class List(RedisCollection, collections.MutableSequence):
-    """Mutable **sequence** collection aiming to have the same API as the
-    standard sequence type, :class:`list`. See Python's `list documentation
-    <http://docs.python.org/2/library/functions.html#list>`_ for
-    further details. The Redis implementation is based on the
-    `list type <http://redis.io/commands#list>`_.
+    """
+    Collection based on the built-in Python :class:`list` type.
+    Items are stored in a Redis list structure.
+    See Python's `list documentation
+    <https://docs.python.org/3/library/stdtypes.html#list>`_ for usage notes.
     """
     _python_cls = list
 
     def __init__(self, *args, **kwargs):
         """
+        Create a new List object.
+
+        If the first argument (*data*) is an iterable object, create the new
+        List with its values as the initial data.
+
         :param data: Initial data.
         :type data: iterable
         :param redis: Redis client instance. If not provided, default Redis
@@ -54,7 +67,7 @@ class List(RedisCollection, collections.MutableSequence):
             self.extend(data)
 
     def _pop_left(self):
-        """Retrieve a value from the 0 index, remove it, and return it."""
+        # Retrieve a value from the 0 index, remove it, and return it.
         pickled_value = self.redis.lpop(self.key)
         if pickled_value is None:
             raise IndexError
@@ -68,7 +81,7 @@ class List(RedisCollection, collections.MutableSequence):
         return value
 
     def _pop_right(self):
-        """Retrieve a value from the -1 index, remove it, and return it."""
+        # Retrieve a value from the -1 index, remove it, and return it.
         if not self.writeback:
             pickled_value = self.redis.rpop(self.key)
             if pickled_value is None:
@@ -91,7 +104,7 @@ class List(RedisCollection, collections.MutableSequence):
         return self._transaction(pop_right_trans)
 
     def _pop_middle(self, index):
-        """Retrieve the value at *index*, remove it, and return it."""
+        # Retrieve the value at *index*, remove it, and return it.
         def pop_middle_trans(pipe):
             len_self, cache_index = self._normalize_index(index, pipe)
             if (cache_index < 0) or (cache_index >= len_self):
@@ -119,7 +132,7 @@ class List(RedisCollection, collections.MutableSequence):
         return self._transaction(pop_middle_trans)
 
     def _del_slice(self, index):
-        """Delete the values associated with :obj:`slice` *index*."""
+        # Delete the values associated with the slice object *index*
         def del_slice_trans(pipe):
             start, stop, step, forward, len_self = self._normalize_slice(
                 index, pipe
@@ -159,7 +172,7 @@ class List(RedisCollection, collections.MutableSequence):
         return self._transaction(del_slice_trans)
 
     def __delitem__(self, index):
-        """Delete the item at **index**."""
+        """Delete the item at *index*."""
         if isinstance(index, slice):
             return self._del_slice(index)
 
@@ -171,9 +184,9 @@ class List(RedisCollection, collections.MutableSequence):
             self._pop_middle(index)
 
     def _get_slice(self, index):
-        """
-        Return the values specified by :obj:`slice` *index* as a :obj:`list`.
-        """
+        # Return the values specified by the slice object *index* as a Python
+        # list
+
         def get_slice_trans(pipe):
             start, stop, step, forward, len_self = self._normalize_slice(
                 index, pipe
@@ -259,10 +272,8 @@ class List(RedisCollection, collections.MutableSequence):
         return reversed(list(self.__iter__()))
 
     def _set_slice(self, index, value):
-        """
-        Set the values for the indexes associated with :obj:`slice` *index*
-        to the contents of the iterable *value*.
-        """
+        # Set the values for the indexes associated with the slice object
+        # *index* to the contents of the iterable *value*
         def set_slice_trans(pipe):
             start, stop, step, forward, len_self = self._normalize_slice(
                 index, pipe
@@ -343,8 +354,9 @@ class List(RedisCollection, collections.MutableSequence):
 
     def copy(self, key=None):
         """
-        Return a new :obj:`List` with the specified *key*. The new collection
-        will have the same values as this collection.
+        Return a new collection with the same items as this one.
+        If *key* is specified, create the new collection with the given
+        Redis key.
         """
         other = self.__class__(
             redis=self.redis, key=key, writeback=self.writeback
@@ -402,7 +414,7 @@ class List(RedisCollection, collections.MutableSequence):
         return self._transaction(index_trans)
 
     def _insert_left(self, value, pipe=None):
-        """Insert *value* at index 0."""
+        # Insert *value* at index 0.
         pipe = self.redis if pipe is None else pipe
         pipe.lpush(self.key, self._pickle(value))
         if self.writeback:
@@ -410,7 +422,7 @@ class List(RedisCollection, collections.MutableSequence):
             self.cache[0] = value
 
     def _insert_middle(self, index, value, pipe=None):
-        """Insert *value* at *index*."""
+        # Insert *value* at *index*.
         pipe = self.redis if pipe is None else pipe
 
         # First, retrieve everything from the index to the end.
@@ -816,13 +828,13 @@ class Deque(List):
 
     def pop(self):
         """
-        Remove and return an element from the right side of the collection.
+        Remove and return an value from the right side of the collection.
         """
         return self._pop_right()
 
     def popleft(self):
         """
-        Remove and return an element from the right side of the collection.
+        Remove and return an value from the right side of the collection.
         """
         return self._pop_left()
 

--- a/redis_collections/sets.py
+++ b/redis_collections/sets.py
@@ -3,7 +3,11 @@
 sets
 ~~~~~
 
-Collections based on the set interface.
+The `sets` module contains a standard collection, :class:`Set`, which is based
+on Python's built-in set type.
+Its elements are stored in a Redis `set <http://redis.io/commands#set>`_
+structure.
+
 """
 from __future__ import division, print_function, unicode_literals
 
@@ -19,11 +23,10 @@ from .base import RedisCollection
 
 class Set(RedisCollection, collections.MutableSet):
     """
-    Mutable **set** collection aiming to have the same API as the standard
-    set type. See Python's `set documentation
-    <http://docs.python.org/2/library/stdtypes.html#set>`_ for
-    further details. The Redis implementation is based on the
-    `set type <http://redis.io/commands#set>`_.
+    Collection based on the built-in Python :class:`set` type.
+    Items are stored in a Redis hash structure.
+    See Python's `set documentation
+    <https://docs.python.org/3/library/stdtypes.html#set>`_ for usage notes.
     """
 
     if six.PY2:
@@ -34,6 +37,11 @@ class Set(RedisCollection, collections.MutableSet):
 
     def __init__(self, *args, **kwargs):
         """
+        Create a new Set object.
+
+        If the first argument (*data*) is an iterable object, create the new
+        Set with its elements as the initial data.
+
         :param data: Initial data.
         :type data: iterable
         :param redis: Redis client instance. If not provided, default Redis
@@ -143,7 +151,7 @@ class Set(RedisCollection, collections.MutableSet):
 
     def random_sample(self, k=1):
         """
-        Return a *k* length list of unique elements chosen from the set.
+        Return a *k* length list of unique elements chosen from the Set.
         Elements are not removed. Similar to :func:`random.sample` function
         from standard library.
 

--- a/redis_collections/sortedsets.py
+++ b/redis_collections/sortedsets.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """
 sortedsets
-~~~~~
+~~~~~~~~~~
 
 Collections based on the Redis Sorted Sets data type
 """

--- a/redis_collections/sortedsets.py
+++ b/redis_collections/sortedsets.py
@@ -3,7 +3,9 @@
 sortedsets
 ~~~~~~~~~~
 
-Collections based on the Redis Sorted Sets data type
+The `sortedsets` module contains a collection, :class:`SortedSetCounter`,
+which provides an interface to Redis's
+`Sorted Set <http://redis.io/commands#set>`_ type.
 """
 from __future__ import division, print_function, unicode_literals
 
@@ -49,6 +51,11 @@ class SortedSetCounter(RedisCollection):
 
     def __init__(self, *args, **kwargs):
         """
+        Create a new SortedSetCounter object.
+
+        If the first argument (*data*) is an iterable object, create the new
+        SortedSetCounter with its elements as the initial data.
+
         :param data: Initial data.
         :type data: iterable or mapping
         :param redis: Redis client instance. If not provided, default Redis

--- a/redis_collections/syncable.py
+++ b/redis_collections/syncable.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """
 syncable
-~~~~~
+~~~~~~~~
 
 Persistent Python collections that can be written to and read from Redis.
 The collections are kept in memory, so their operations run as fast as their


### PR DESCRIPTION
This PR makes several changes to the API documentation. See the results at [ReadTheDocs](http://redis-collections.readthedocs.io/en/api-doc-updates/api.html). Changes are mainly focused on improving clarity, spelling, and formatting.