### PR TITLE
Syncable Deque

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,7 +28,7 @@ Python counterparts:
 .. code-block:: python
 
     >>> from redis_collections import Dict, List, Set
-    
+
     >>> D = Dict()
     >>> D['answer'] = 42
     >>> D['answer']
@@ -60,7 +60,7 @@ contents are written to Redis:
 .. code-block:: python
 
     >>> from redis_collections import SyncableDict
-    
+
     >>> with SyncableDict() as D:
     ...     D['a'] = 1  # No write to Redis
     ...     D['a'] += 1  # No read from or write to Redis
@@ -77,6 +77,8 @@ contents are written to Redis:
 | ``SyncableSet``         | ``set``                     | Syncs to a Redis Set  |
 +-------------------------+-----------------------------+-----------------------+
 | ``SyncableCounter``     | ``collections.Counter``     | Syncs to a Redis Hash |
++-------------------------+-----------------------------+-----------------------+
+| ``SyncableDeque``       | ``collections.deque``       | Syncs to a Redis List |
 +-------------------------+-----------------------------+-----------------------+
 | ``SyncableDefaultDict`` | ``collections.defaultdict`` | Syncs to a Redis Hash |
 +-------------------------+-----------------------------+-----------------------+
@@ -95,7 +97,7 @@ It pushes older items to Redis:
     >>> D['a'] = 1
     >>> D['b'] = 2
     >>> D['c'] = 2  # 'a' is pushed to Redis and 'c' is stored locally
-    >>> D['a']  # 'b' is pushed to Redis and 'a' is retrieved for local storage 
+    >>> D['a']  # 'b' is pushed to Redis and 'a' is retrieved for local storage
     1
     >>> D.sync()  # All items are copied to Redis
 

--- a/redis_collections/__init__.py
+++ b/redis_collections/__init__.py
@@ -17,6 +17,7 @@ from .syncable import (  # NOQA
     LRUDict,
     SyncableDict,
     SyncableCounter,
+    SyncableDeque,
     SyncableDefaultDict,
     SyncableList,
     SyncableSet,
@@ -35,6 +36,7 @@ __all__ = [
     'SyncableDict',
     'SyncableCounter',
     'SyncableDefaultDict',
+    'SyncableDeque',
     'SyncableList',
     'SyncableSet',
 ]

--- a/redis_collections/lists.py
+++ b/redis_collections/lists.py
@@ -653,12 +653,12 @@ class Deque(List):
     """
     _python_cls = collections.deque
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, iterable=None, maxlen=None, **kwargs):
         """
         Create a new Deque object.
 
-        If the first argument (*data*) is an iterable object, create the new
-        Deque with its values as the initial data.
+        If the first argument (*iterable*) is an iterable object, create the
+        new Deque with its values as the initial data.
 
         If the second argument (*maxlen*) is an integer, create the Deque with
         the given maximum length.
@@ -669,7 +669,7 @@ class Deque(List):
         maximum length), adding new items to one side will cause a
         corresponding number of items to be removed from the other side.
 
-        :param data: Initial data.
+        :param iterable: Initial data.
         :type data: iterable
         :param maxlen: Maximum size.
         :type maxlen: int
@@ -689,14 +689,8 @@ class Deque(List):
             The ``maxlen`` of the collection can't be enforced when multiple
             processes are accessing its Redis collection.
         """
-        if len(args) > 2:
-            msg = '{} takes at most 2 positional arguments ({} given)'
-            raise TypeError(msg.format(self.__class__, len(args)))
-        elif len(args) == 2:
-            maxlen = args[1]
-            args = args[:1]
-        else:
-            maxlen = None
+        if iterable is not None:
+            kwargs['data'] = iterable
 
         if (maxlen is not None) and not isinstance(maxlen, six.integer_types):
             raise TypeError('an integer is required')
@@ -705,7 +699,7 @@ class Deque(List):
             raise ValueError('maxlen must be non-negative')
 
         self.maxlen = maxlen
-        super(Deque, self).__init__(*args, **kwargs)
+        super(Deque, self).__init__(**kwargs)
 
     # Magic methods
 

--- a/redis_collections/syncable.py
+++ b/redis_collections/syncable.py
@@ -32,7 +32,7 @@ from __future__ import division, print_function, unicode_literals
 import collections
 
 from .dicts import Counter, DefaultDict, Dict
-from .lists import List
+from .lists import Deque, List
 from .sets import Set
 
 
@@ -127,6 +127,26 @@ class SyncableList(_SyncableBase, list):
         self.persistence = List(**kwargs)
 
         super(SyncableList, self).__init__()
+        self.extend(self.persistence)
+
+    def sync(self):
+        self.persistence.clear()
+        self.persistence.extend(self)
+
+
+class SyncableDeque(_SyncableBase, collections.deque):
+    """
+    :class:`deque` subclass whose contents can be synced to Redis.
+
+    See Python's `deque documentation
+    <https://docs.python.org/3/library/collections.html#collections.deque>`_
+    for details.
+    """
+
+    def __init__(self, iterable=None, maxlen=None, **kwargs):
+        self.persistence = Deque(iterable=iterable, maxlen=maxlen, **kwargs)
+
+        super(SyncableDeque, self).__init__(maxlen=self.persistence.maxlen)
         self.extend(self.persistence)
 
     def sync(self):

--- a/tests/test_lists.py
+++ b/tests/test_lists.py
@@ -586,6 +586,14 @@ class DequeTest(RedisTestCase):
             self.assertEqual(list(Q), list('abcd'))
             self.assertIsNone(Q.maxlen)
 
+            Q = init(iterable='abcd')
+            self.assertEqual(list(Q), list('abcd'))
+            self.assertIsNone(Q.maxlen)
+
+            Q = init(maxlen=4)
+            self.assertEqual(list(Q), [])
+            self.assertEqual(Q.maxlen, 4)
+
             self.assertRaises(TypeError, init, 'abcd', Ellipsis)
 
             self.assertRaises(ValueError, init, 'abcd', -4)


### PR DESCRIPTION
This PR adds `SyncableDeque`. Now each of the standard "auto-sync to Redis" collections has a corresponding "manual-sync to Redis" collection.

I think this will be the last change before version 0.4.0.