### PR TITLE
Make setup.py keywords a list

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
     include_package_data=True,
     install_requires=['redis>=2.7.2', 'six>=1.10.0'],
     zip_safe=False,
-    keywords='redis persistence',
+    keywords=['redis', 'persistence'],
     classifiers=(
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',


### PR DESCRIPTION
This PR makes the `keywords` argument to `setup.py`'s `setup` a list instead of a string. I think the [docs](https://packaging.python.org/distributing/#keywords) are wrong for that... (see [here](https://pypi.python.org/pypi/redis-collections/0.4.0)).