### PR TITLE
Implement SCAN for hashes, sets, and sorted sets

### DIFF
--- a/redis_collections/sets.py
+++ b/redis_collections/sets.py
@@ -195,6 +195,22 @@ class Set(RedisCollection, collections.MutableSet):
         if not result:
             raise KeyError(value)
 
+    def scan_elements(self):
+        """
+        Yield each of the elements from the collection, without pulling them
+        all into memory.
+
+        .. warning::
+            This method is not available on the set collections provided
+            by Python.
+
+            This method may return the element multiple times.
+            See the `Redis SCAN documentation
+            <http://redis.io/commands/scan#scan-guarantees>`_ for details.
+        """
+        for x in self.redis.sscan_iter(self.key):
+            yield self._unpickle(x)
+
     # Comparison and set operation helpers
 
     def _ge_helper(self, other, op, check_type=False):

--- a/redis_collections/sortedsets.py
+++ b/redis_collections/sortedsets.py
@@ -317,6 +317,20 @@ class SortedSetCounter(RedisCollection):
 
         return ret
 
+    def scan_items(self):
+        """
+        Yield each of the ``(member, score)`` tuples from the collection,
+        without pulling them all into memory.
+
+        .. warning::
+            This method may return the same (member, score) tuple multiple
+            times.
+            See the `Redis SCAN documentation
+            <http://redis.io/commands/scan#scan-guarantees>`_ for details.
+        """
+        for m, s in self.redis.zscan_iter(self.key):
+            yield self._unpickle(m), s
+
     def set_score(self, member, score, pipe=None):
         """
         Set the score of *member* to *score*.

--- a/tests/test_dicts.py
+++ b/tests/test_dicts.py
@@ -405,6 +405,19 @@ class DictTest(RedisTestCase):
         redis_dict = self.create_dict()
         self.assertEqual(repr(redis_dict._Dict__marker), '<missing value>')
 
+    def test_scan_items(self):
+        redis_dict = self.create_dict()
+
+        expected_dict = {}
+        for i in six.moves.range(1000):
+            expected_dict[i] = i * 100.0
+            redis_dict[i] = i * 100.0
+
+        items = list(redis_dict.scan_items())
+        self.assertTrue(len(items) >= 1000)
+
+        self.assertTrue(dict(items), expected_dict)
+
 
 class CounterTest(RedisTestCase):
 

--- a/tests/test_sets.py
+++ b/tests/test_sets.py
@@ -7,6 +7,8 @@ from fractions import Fraction
 import unittest
 import sys
 
+import six
+
 from redis_collections import List, Set
 
 from .base import RedisTestCase
@@ -458,6 +460,20 @@ class SetTest(RedisTestCase):
         redis_set = self.create_set()
         redis_set.add(1)
         redis_set.sync()
+
+    def test_scan_elements(self):
+        redis_set = self.create_set()
+
+        expected_elements = set()
+        for i in six.moves.range(1000):
+            elem = str(i)
+            expected_elements.add(elem)
+            redis_set.add(elem)
+
+        actual_elements = list(redis_set)
+        self.assertTrue(len(actual_elements) >= len(expected_elements))
+
+        self.assertEqual(set(actual_elements), expected_elements)
 
 
 class _Set(Set):

--- a/tests/test_sortedsets.py
+++ b/tests/test_sortedsets.py
@@ -2,6 +2,8 @@ from __future__ import print_function, unicode_literals
 
 from redis_collections import SortedSetCounter
 
+import six
+
 from .base import RedisTestCase
 
 
@@ -215,6 +217,19 @@ class SortedSetCounterTestCase(RedisTestCase):
         self.assertEqual(ssc.items(max_rank=4, min_score=4), items[2:5])
         self.assertEqual(ssc.items(1, 4, 4, 8), items[2:4])
         self.assertEqual(ssc.items(1, 4, 4, 8, reverse=True), items[3:1:-1])
+
+    def test_scan_items(self):
+        ssc = self.create_sortedset()
+
+        expected_dict = {}
+        for i in six.moves.range(1000):
+            expected_dict[i] = i * 100.0
+            ssc.set_score(i, i * 100.0)
+
+        items = list(ssc.scan_items())
+        self.assertTrue(len(items) >= 1000)
+
+        self.assertTrue(dict(items), expected_dict)
 
     def test_update(self):
         ssc = self.create_sortedset([('member_1', 0.0)])


### PR DESCRIPTION
Re: #75, this PR adds support for the Redis SCAN commands on Hashes, Sets, and Sorted Sets.

As the Redis docs [note](http://redis.io/commands/scan#scan-guarantees):
> A given element may be returned multiple times. It is up to the application to handle the case of duplicated elements, for example only using the returned elements in order to perform operations that are safe when re-applied multiple times.

There's no good workaround for this, so I've added new scan methods instead of replacing e.g. `iteritems`.

This PR uses the [scan iterators](https://github.com/andymccurdy/redis-py#scan-iterators) from the redis-py package.

```python
>>> from redis_collections import Dict
... 
... D = Dict((x, str(x)) for x in range(1000))
... 
... for k, v in D.scan_items():
...     print(k, v, sep='\t')
222	222
119	119
508	508
456	456
...
```