### PR TITLE
Lazily retrieve REDIS version, so existing code will not break and no…

### DIFF
--- a/redis_collections/base.py
+++ b/redis_collections/base.py
@@ -44,12 +44,20 @@ class RedisCollection(object):
         #: Redis client instance. :class:`StrictRedis` object with default
         #: connection settings is used if not set by :func:`__init__`.
         self.redis = redis or self._create_redis()
-        self.redis_version = tuple(
-            int(x) for x in self.redis.info()['redis_version'].split('.')
-        )
-
         #: Redis key of the collection.
         self.key = key or self._create_key()
+
+    _redis_versions = {}
+
+    @property
+    def redis_version(self):
+        """Cache REDIS server version after initial query, for all devired types
+        """
+        if self.redis not in RedisCollection._redis_versions:
+            RedisCollection._redis_versions[self.redis] = tuple(
+                int(x) for x in self.redis.info()['redis_version'].split('.')
+            )
+        return RedisCollection._redis_versions[self.redis]
 
     def _create_redis(self):
         """


### PR DESCRIPTION
… REDIS access is done during redis-collection object instantiation

Hi,

I'm using code that relies that no initial REDIS connection is done during instantiation of global redis-collection objects!

Unfortunately, change in a50629550d40382cc51d898830df2d9307c6a6f5 retrieves the REDIS server version, which is both not necessary at that point, and it it does for EVERY single instantiated object.

The code changed tries to fix both issues.

My point is that it is sufficient to retrieve the version ONCE and only when really needed (as in SortedSets), so some "lazy attribute" stuff. You get the idea.. it could be done with LazyObject stuff, but that would require more external dependencies..

Cheers and thanks for your work!