### PR TITLE
Add pickle_protocol argument to base class

### DIFF
--- a/docs/usage-notes.rst
+++ b/docs/usage-notes.rst
@@ -36,6 +36,16 @@ Each collection allows you to delete its Redis key with the `clear` method:
     >>> D.clear()
     >>> list(D.items())
 
+.. note::
+    Stored objects are serialized with Python-standard pickling.
+    By default, the `highest protocol version
+    <https://docs.python.org/3/library/pickle.html#pickle.HIGHEST_PROTOCOL>`_
+    is used.
+    It's not recommended to retrieve objects created by one version of Python
+    with another version.
+    However, If you must do that, set the ``pickle_protocol`` keyword argument
+    to ``2`` or lower when declaring a collection.
+
 
 Redis connection
 ----------------
@@ -172,8 +182,8 @@ If you are not satisfied with that function's
 sublclass a collection and override its :func:`_create_key` method.
 
 If you don't like how  :mod:`pickle` does serialization, you may override the
-``_pickle`` and ``_unpickle`` methods of the collection classes. Using other
-serializers will limit the objects you can store or retrieve.
+``_pickle*`` and ``_unpickle*`` methods on the collection classes.
+Using other serializers will limit the objects you can store or retrieve.
 
 .. note::
     On Python 2, the :mod:`pickle` module is used instead of the

--- a/docs/usage-notes.rst
+++ b/docs/usage-notes.rst
@@ -43,8 +43,9 @@ Each collection allows you to delete its Redis key with the `clear` method:
     is used.
     It's not recommended to retrieve objects created by one version of Python
     with another version.
-    However, If you must do that, set the ``pickle_protocol`` keyword argument
-    to ``2`` or lower when declaring a collection.
+    If you attempt to do that, be sure to set the ``pickle_protocol`` keyword
+    argument to a version that both Python versions support when
+    declaring a collection.
 
 
 Redis connection

--- a/redis_collections/base.py
+++ b/redis_collections/base.py
@@ -53,7 +53,6 @@ class RedisCollection(object):
 
         self.pickle_protocol = pickle_protocol
 
-
     def _create_redis(self):
         """
         Creates a new Redis connection when none is specified during

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,4 +3,4 @@ universal = 1
 
 [flake8]
 exclude = ./docs/conf.py
-ignore = E731
+ignore = E731, F999

--- a/tests/test_lists.py
+++ b/tests/test_lists.py
@@ -848,5 +848,6 @@ class DequeTest(RedisTestCase):
             Q.rotate()
             self.assertEqual(Q[0], [1, 2, 3])
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_syncable.py
+++ b/tests/test_syncable.py
@@ -380,5 +380,6 @@ class LRUDictTest(RedisTestCase):
         self.assertEqual(lru_dict.persistence['b'], -2)
         self.assertEqual(len(lru_dict.cache), 0)
 
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR adds a `pickle_protocol` argument to the `RedisCollection` class's constructor. It changes the default protocol from 0 to 2 on Python 2.7 and from `DEFAULT_PROTOCOL` to `HIGHEST_PROTOCOL` on Python 3.x.

The docs are also updated to recommend against using multiple Python versions to access a Redis collection.

This will be released as 0.5.x instead of 0.4.x, since currently Python 3.3 and 3.4+ would both be using protocol version 3.