### PR TITLE
Add support for Unix sockets in _same_redis

### DIFF
--- a/redis_collections/base.py
+++ b/redis_collections/base.py
@@ -174,8 +174,9 @@ class RedisCollection(object):
         other_kwargs = other.redis.connection_pool.connection_kwargs
 
         return (
-            self_kwargs['host'] == other_kwargs['host'] and
-            self_kwargs['port'] == other_kwargs['port'] and
+            self_kwargs.get('host') == other_kwargs.get('host') and
+            self_kwargs.get('port') == other_kwargs.get('port') and
+            self_kwargs.get('path') == other_kwargs.get('path') and
             self_kwargs.get('db', 0) == other_kwargs.get('db', 0)
         )
 


### PR DESCRIPTION
The `RedisCollection._same_redis` method checks the `connection_pool.connection_kwargs` dict of the `StrictRedis` instance to determine whether two collections are using the same Redis server.

That dict has `host` and `port` entries when Redis is listening on a network socket, but a `path` entry when Redis is using a domain socket.

This PR changes  `_same_redis` to support the `path` entry.

```python
{'db': 0,
 'decode_responses': False,
 'encoding': 'utf-8',
 'encoding_errors': 'strict',
 'password': None,
 'path': '/tmp/tmp5qhsjU/redis.socket',
 'retry_on_timeout': False,
 'socket_timeout': None}
```