### PR TITLE
Save some memory when doing Dict.update

### DIFF
--- a/redis_collections/dicts.py
+++ b/redis_collections/dicts.py
@@ -333,15 +333,16 @@ class Dict(RedisCollection, collections.MutableMapping):
             else:
                 data.update(other)
 
+            if self.writeback:
+                self.cache.update(data)
+
             pickled_data = {}
-            for k, v in six.iteritems(data):
+            while data:
+                k, v = data.popitem()
                 pickled_data[self._pickle_key(k)] = self._pickle_value(v)
 
             if pickled_data:
                 pipe.hmset(self.key, pickled_data)
-
-            if self.writeback:
-                self.cache.update(data)
 
         if use_redis:
             self._transaction(_update_helper_trans, other.key)

--- a/redis_collections/dicts.py
+++ b/redis_collections/dicts.py
@@ -333,20 +333,16 @@ class Dict(RedisCollection, collections.MutableMapping):
             else:
                 data.update(other)
 
-            if not data:
-                return
-
             if self.writeback:
                 self.cache.update(data)
 
-            def _yield_pickled(data):
-                while data:
-                    k, v = data.popitem()
-                    yield self._pickle_key(k)
-                    yield self._pickle_value(v)
+            pickled_data = {}
+            while data:
+                k, v = data.popitem()
+                pickled_data[self._pickle_key(k)] = self._pickle_value(v)
 
-            pickled_items = _yield_pickled(data)
-            pipe.execute_command('HMSET', self.key, *pickled_items)
+            if pickled_data:
+                pipe.hmset(self.key, pickled_data)
 
         if use_redis:
             self._transaction(_update_helper_trans, other.key)


### PR DESCRIPTION
This PR reduces memory usage a bit during the `Dict.update` operation.

Before: A `data` dict would be created for the items to be inserted, and then a dict of pickled data would be created from that.

After: The pickled dict is filled by popping items out of the `data` dict, to avoid having two copies at once. Due to Python internals this isn't quite the memory savings you would think, but it's something.

[redis-py](https://redis-py.readthedocs.io/en/latest/_modules/redis/client.html#StrictRedis.hmset) makes more copies of the data, so there is probably some more efficiency that could be had here.