### PR TITLE
Feature Added: factory.RedisCollectionsFactory

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -115,6 +115,25 @@ The ``SortedSetCounter`` provides access to the Redis
     >>> ssc.items()
     [('mercury', 100.0), ('venus', 200.0), ('earth', 300.0)]
 
+
+
+RedisCollectionsFactory
+^^^^^^^^^^^^^^^^^^^^^^^
+
+``RedisCollectionsFactory`` exposes redis-py API along with all redis-collections types
+
+The redis-collections type no longer need to have the `redis` upon initialization.
+
+However, the `key` is now required.
+
+   >>> from redis_collections import RedisCollectionsFactory
+
+   >>> col = RedisCollectionsFactory.from_url("redis://")
+   >>> my_dict = col.Dict("my_dict", {})
+   >>> my_list = col.List("my_list", [])
+
+
+
 Documentation
 -------------
 

--- a/redis_collections/__init__.py
+++ b/redis_collections/__init__.py
@@ -39,4 +39,7 @@ __all__ = [
     'SyncableDeque',
     'SyncableList',
     'SyncableSet',
+    'RedisCollectionsFactory'
 ]
+
+from .factory import RedisCollectionsFactory

--- a/redis_collections/factory.py
+++ b/redis_collections/factory.py
@@ -1,0 +1,101 @@
+# -*- coding: utf-8 -*-
+"""
+RedisCollectionsFactory
+@author: Mardix - https://github.com/mardix
+"""
+
+import redis
+from . import (
+    Counter,
+    DefaultDict,
+    Deque,
+    Dict,
+    List,
+    Set,
+    SortedSetCounter,
+    LRUDict,
+    SyncableDict,
+    SyncableCounter,
+    SyncableDeque,
+    SyncableDefaultDict,
+    SyncableList,
+    SyncableSet,
+)
+
+
+class RedisCollectionsFactory(redis.Redis):
+    """
+    This class factory exposes the redis-py methods
+    along with the redis collections
+    At a minimum the collections type require a key name, and it will use
+    the current collection as redis connection.
+
+    Examples:
+
+    my_redis = RedisCollectionsFactory.from_url("redis://x:x@host.com/dbname")
+
+    my_dict = my_redis.Dict(key, {"a": "b"}, ...)
+    my_list = my_redis.List(key, ["A", "B", "C"]...)
+
+    you still can use redis native:
+
+    my_redis.set(key, value)
+    my_redis.get(key)
+
+    """
+
+    def Counter(self, key, *args, **kwargs):
+        kwargs.update({"key": key, "redis": self})
+        return Counter(*args, **kwargs)
+
+    def DefaultDict(self, key, *args, **kwargs):
+        kwargs.update({"key": key, "redis": self})
+        return DefaultDict(*args, **kwargs)
+
+    def Deque(self, key, **kwargs):
+        kwargs.update({"key": key, "redis": self})
+        return Deque(**kwargs)
+
+    def Dict(self, key, *args, **kwargs):
+        kwargs.update({"key": key, "redis": self})
+        return Dict(*args, **kwargs)
+
+    def List(self, key, *args, **kwargs):
+        kwargs.update({"key": key, "redis": self})
+        return List(*args, **kwargs)
+
+    def LRUDict(self, key, **kwargs):
+        kwargs.update({"key": key, "redis": self})
+        return LRUDict(**kwargs)
+
+    def Set(self, key, *args, **kwargs):
+        kwargs.update({"key": key, "redis": self})
+        return Set(*args, **kwargs)
+
+    def SortedSetCounter(self, key, *args, **kwargs):
+        kwargs.update({"key": key, "redis": self})
+        return SortedSetCounter(*args, **kwargs)
+
+    def SyncableDict(self, key, **kwargs):
+        kwargs.update({"key": key, "redis": self})
+        return SyncableDict(**kwargs)
+
+    def SyncableCounter(self, key, **kwargs):
+        kwargs.update({"key": key, "redis": self})
+        return SyncableCounter(**kwargs)
+
+    def SyncableDefaultDict(self, key, *args, **kwargs):
+        kwargs.update({"key": key, "redis": self})
+        return SyncableDefaultDict(*args, **kwargs)
+
+    def SyncableDeque(self, key, *args, **kwargs):
+        kwargs.update({"key": key, "redis": self})
+        return SyncableDeque(*args, **kwargs)
+
+    def SyncableList(self, key, **kwargs):
+        kwargs.update({"key": key, "redis": self})
+        return SyncableList(**kwargs)
+
+    def SyncableSet(self, key, **kwargs):
+        kwargs.update({"key": key, "redis": self})
+        return SyncableSet(**kwargs)

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+from __future__ import division, print_function, unicode_literals
+import unittest
+import redis_collections as rc
+
+
+class RedisCollectionsFactoryTest(unittest.TestCase):
+
+    def test_factory(self):
+        coll = [
+            'Counter',
+            'DefaultDict',
+            'Deque',
+            'Dict',
+            'List',
+            'LRUDict',
+            'Set',
+            'SortedSetCounter',
+            'SyncableDict',
+            'SyncableCounter',
+            'SyncableDefaultDict',
+            'SyncableDeque',
+            'SyncableList',
+            'SyncableSet',
+        ]
+
+        factory = rc.RedisCollectionsFactory.from_url("redis://")
+        for c in coll:
+            native = getattr(rc, c)
+            factor = getattr(factory, c)
+            self.assertIsInstance(factor(key=c), native)
+
+
+if __name__ == '__main__':
+    unittest.main()
+


### PR DESCRIPTION
``RedisCollectionsFactory`` exposes redis-py API along with all redis-collections types

The redis-collections type no longer need to have the `redis` upon initialization.

However, the `key` is now required.

   >>> from redis_collections import RedisCollectionsFactory

   >>> col = RedisCollectionsFactory.from_url("redis://")
   >>> my_dict = col.Dict("my_dict", {})
   >>> my_list = col.List("my_list", [])
