### PR TITLE
 Note breaking changes re: pickling 

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -26,10 +26,20 @@ Breaking changes
 0.5.x
 ^^^^^
 
-The 3.0.x release of `redis-py` is now required. Since it's not
-backward-compatible with older versions, this library had to change as well.
+- The 3.0.x release of `redis-py` is now required. Since it's not
+  backward-compatible with older versions, this library had to change as well.
 
-In addition, Python 3.3 is no longer supported.
+- Data is now pickled using the highest protocol version supported by Python.
+
+  You can specify the ``pickle_protocol`` with a keyword argument - see
+  :ref:`usage-notes`.
+
+  To connect to a collection created with an older version of this package,
+  set ``pickle_protocol=None``.
+
+  See also `PR #101 <https://github.com/honzajavorek/redis-collections/pull/101>`_.
+
+- Python 3.3 is no longer supported.
 
 0.4.x
 ^^^^^

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -75,6 +75,11 @@ New features
 0.4.x
 ^^^^^
 
+0.4.2 includes:
+
+- Fixed support for using a Redis server listening on a Unix domain socket
+  instead of a network socket.
+
 0.4.1 includes:
 
 - Redis-specific ``scan_`` methods on ``Dict`` (and its subclassess), ``Set``,


### PR DESCRIPTION
Re: https://github.com/honzajavorek/redis-collections/issues/112, this PR adds a note on incompatibility between versions 0.4.x and 0.5.x.

As noted [here](https://github.com/honzajavorek/redis-collections/issues/112#issuecomment-443392441), you can connect to a collection created by 0.4.x by specifying which pickle protocol version to use.