### PR TITLE
Remove sudo:false from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: false
 language: "python"
 dist: xenial
 


### PR DESCRIPTION
This PR changes the `.travis.yml` configuration - see [this blog post](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration).