### PR TITLE
Add GeoDB class

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -58,7 +58,12 @@ from ``redis_collections`` package.
 
 .. autoclass:: SortedSetCounter
     :members:
-    :special-members:
+    :inherited-members:
+
+.. autoclass:: GeoDB
+    :members:
+    :inherited-members:
+
 
 ----
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -11,8 +11,8 @@ Versioning
 A 1.0 release is planned. Before that happens:
 
 - Releases with significant new features or breaking changes will be tagged as
-  0.6.x, 0.7.x, etc.
-- Bug fix releases will be tagged as 0.5.x
+  0.7.x, 0.8.x, etc.
+- Bug fix releases will be tagged as 0.6.x
 
 After 1.0 is released:
 
@@ -22,6 +22,12 @@ After 1.0 is released:
 
 Breaking changes
 ----------------
+
+0.6.x
+^^^^^
+
+- The 3.1.x release of `redis-py` is now required. This isn't explicitly
+  backward-incompatible, but be aware.
 
 0.5.x
 ^^^^^
@@ -81,6 +87,13 @@ Nothing should have broken from 0.3.x to 0.4.x.
 
 New features
 ------------
+
+0.6.x
+^^^^^
+
+0.6.0 includes:
+
+- Added the ``GeoDB`` collection, a high-level interface for Redis's GEO commands.
 
 0.4.x
 ^^^^^

--- a/redis_collections/__init__.py
+++ b/redis_collections/__init__.py
@@ -12,7 +12,7 @@ from .base import RedisCollection  # NOQA
 from .dicts import DefaultDict, Dict, Counter  # NOQA
 from .lists import Deque, List  # NOQA
 from .sets import Set  # NOQA
-from .sortedsets import SortedSetCounter  # NOQA
+from .sortedsets import GeoDB, SortedSetCounter  # NOQA
 from .syncable import (  # NOQA
     LRUDict,
     SyncableDict,
@@ -28,6 +28,7 @@ __all__ = [
     'DefaultDict',
     'Deque',
     'Dict',
+    'GeoDB',
     'List',
     'LRUDict',
     'RedisCollection',

--- a/redis_collections/__init__.py
+++ b/redis_collections/__init__.py
@@ -2,7 +2,7 @@
 from __future__ import division, print_function, unicode_literals
 
 __title__ = 'redis-collections'
-__version__ = '0.5.2'
+__version__ = '0.6.0'
 __author__ = 'Honza Javorek'
 __license__ = 'ISC'
 __copyright__ = 'Copyright 2013-? Honza Javorek'

--- a/redis_collections/base.py
+++ b/redis_collections/base.py
@@ -174,8 +174,9 @@ class RedisCollection(object):
         other_kwargs = other.redis.connection_pool.connection_kwargs
 
         return (
-            self_kwargs['host'] == other_kwargs['host'] and
-            self_kwargs['port'] == other_kwargs['port'] and
+            self_kwargs.get('host') == other_kwargs.get('host') and
+            self_kwargs.get('port') == other_kwargs.get('port') and
+            self_kwargs.get('path') == other_kwargs.get('path') and
             self_kwargs.get('db', 0) == other_kwargs.get('db', 0)
         )
 

--- a/redis_collections/sets.py
+++ b/redis_collections/sets.py
@@ -278,7 +278,7 @@ class Set(RedisCollection, collections_abc.MutableSet):
             check_type and
             not all(isinstance(x, collections_abc.Set) for x in others)
         ):
-                raise TypeError
+            raise TypeError
 
         def op_update_trans_pure(pipe):
             method = getattr(pipe, redis_op)

--- a/redis_collections/sortedsets.py
+++ b/redis_collections/sortedsets.py
@@ -462,11 +462,11 @@ class GeoDB(SortedSetBase):
         """
         pickled_place = self._pickle(place)
         try:
-            response = self.redis.geopos(self.key, pickled_place)[0]
+            longitude, latitude = self.redis.geopos(self.key, pickled_place)[0]
         except (AttributeError, TypeError):
             return None
 
-        return {'latitude': response[1], 'longitude': response[0]}
+        return {'latitude': latitude, 'longitude': longitude}
 
     def places_within_radius(
         self, place=None, latitude=None, longitude=None, radius=0, **kwargs
@@ -492,7 +492,7 @@ class GeoDB(SortedSetBase):
         kwargs['withdist'] = True
         kwargs['withcoord'] = True
         kwargs['withhash'] = False
-        kwargs.setdefault('sort', b'ASC')
+        kwargs.setdefault('sort', 'ASC')
         unit = kwargs.setdefault('unit', 'km')
 
         # Make the query

--- a/redis_collections/sortedsets.py
+++ b/redis_collections/sortedsets.py
@@ -133,7 +133,16 @@ class SortedSetCounter(SortedSetBase):
         >>> ssc.items(min_score=99, max_score=299)
         [('mercury', 100.0), ('venus', 200.0)]
 
-    .. warning::
+    Collections support the ``in`` operator, and can be iterated over:
+
+        >>> 'mercury' in ssc
+        True
+        >>> list(ssc)
+         [('mercury', 100.0), ('venus', 200.0), ('earth', 300.0)]
+        >>> len(ssc)
+        3
+
+    .. note::
         The API for :class:`SortedSetCounter` does not attempt to match an
         existing Python collection's.
 

--- a/redis_collections/sortedsets.py
+++ b/redis_collections/sortedsets.py
@@ -416,9 +416,15 @@ class GeoDB(SortedSetBase):
         The default unit is ``'km'``, but ``'m'``, ``'mi'``, and ``'ft'`` can
         also be specified.
         """
-        return self.redis.geodist(
-            self.key, self._pickle(place_1), self._pickle(place_2), unit=unit
-        )
+        try:
+            return self.redis.geodist(
+                self.key,
+                self._pickle(place_1),
+                self._pickle(place_2),
+                unit=unit
+            )
+        except TypeError:
+            return None
 
     def get_hash(self, place):
         """
@@ -445,7 +451,7 @@ class GeoDB(SortedSetBase):
 
         return {'latitude': response[1], 'longitude': response[0]}
 
-    def get_within_radius(
+    def places_within_radius(
         self, place=None, latitude=None, longitude=None, radius=0, **kwargs
     ):
         """

--- a/redis_collections/sortedsets.py
+++ b/redis_collections/sortedsets.py
@@ -412,6 +412,18 @@ class GeoDB(SortedSetBase):
                 'longitude': item['longitude'],
             }
 
+    def __getitem__(self, place):
+        ret = self.get_location(place)
+        if ret is None:
+            raise KeyError(place)
+
+        return ret
+
+    def __setitem__(self, place, location):
+        return self.set_location(
+            place, location['latitude'], location['longitude']
+        )
+
     def distance_between(self, place_1, place_2, unit='km'):
         """
         Return the great-circle distance between *place_1* and *place_2*,

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
     license='ISC',
     packages=find_packages(exclude=['tests']),
     include_package_data=True,
-    install_requires=['redis>=3.0.1,<4.0.0', 'six'],
+    install_requires=['redis>=3.1.0,<4.0.0', 'six'],
     zip_safe=False,
     keywords=['redis', 'persistence'],
     classifiers=(
@@ -57,7 +57,6 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: ISC License (ISCL)',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Topic :: Database',

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
     license='ISC',
     packages=find_packages(exclude=['tests']),
     include_package_data=True,
-    install_requires=['redis>=3.0.1,<4.0.0'],
+    install_requires=['redis>=3.0.1,<4.0.0', 'six'],
     zip_safe=False,
     keywords=['redis', 'persistence'],
     classifiers=(

--- a/tests/test_lists.py
+++ b/tests/test_lists.py
@@ -527,7 +527,7 @@ class ListTest(RedisTestCase):
         self.assertEqual(redis_cached.index(['tbaker']), 3)
         self.assertEqual(redis_cached.index(['tbaker'], 4), 4)
         with self.assertRaises(ValueError):
-                redis_cached.index(['tbaker'], 0, 2)
+            redis_cached.index(['tbaker'], 0, 2)
 
         # remove (forces sync)
         redis_cached.remove(['tbaker'])

--- a/tests/test_sortedsets.py
+++ b/tests/test_sortedsets.py
@@ -250,21 +250,7 @@ class SortedSetCounterTestCase(RedisTestCase):
         self.assertEqual(ssc.get_score('member_3'), 40.0)
 
 
-class GeoDBTestCase(TestCase):
-    def setUp(self):
-        # Hack for 2016-11-27: released version of redis doesn't support
-        # GEO commands yet, but a custom version of redislite does.
-        from redislite import StrictRedis
-        db = 15
-        self.redis = StrictRedis(db=db)
-        if self.redis.dbsize():
-            raise EnvironmentError(
-                'Redis database number {} is not empty'.format(db)
-            )
-
-    def tearDown(self):
-        self.redis.flushdb()
-
+class GeoDBTestCase(RedisTestCase):
     def create_geodb(self, *args, **kwargs):
         kwargs['redis'] = self.redis
         return GeoDB(*args, **kwargs)
@@ -362,7 +348,7 @@ class GeoDBTestCase(TestCase):
 
         # Test sort descending
         response = geodb.places_within_radius(
-            place='St. Louis', radius=7530, sort=b'DESC'
+            place='St. Louis', radius=7530, sort='DESC'
         )
         self.assertEqual(response[0]['place'], 'Bahia')
 

--- a/tests/test_sortedsets.py
+++ b/tests/test_sortedsets.py
@@ -1,7 +1,5 @@
 from __future__ import print_function, unicode_literals
 
-from unittest import TestCase
-
 from redis_collections import GeoDB, SortedSetCounter
 
 import six

--- a/tests/test_sortedsets.py
+++ b/tests/test_sortedsets.py
@@ -269,6 +269,17 @@ class GeoDBTestCase(TestCase):
         kwargs['redis'] = self.redis
         return GeoDB(*args, **kwargs)
 
+    def test_getitem(self):
+        geodb = self.create_geodb()
+        geodb.set_location('St. Louis', 38.6270, -90.1994)
+
+        actual = geodb['St. Louis']
+        self.assertAlmostEqual(actual['latitude'], 38.6270, places=4)
+        self.assertAlmostEqual(actual['longitude'], -90.1994, places=4)
+
+        with self.assertRaises(KeyError):
+            geodb['Bahia']
+
     def test_iter(self):
         geodb = self.create_geodb()
         geodb.set_location('St. Louis', 38.6270, -90.1994)

--- a/tests/test_sortedsets.py
+++ b/tests/test_sortedsets.py
@@ -277,6 +277,14 @@ class GeoDBTestCase(TestCase):
         self.assertAlmostEqual(actual['latitude'], 38.6270, places=4)
         self.assertAlmostEqual(actual['longitude'], -90.1994, places=4)
 
+    def test_setitem(self):
+        geodb = self.create_geodb()
+        geodb['St. Louis'] = {'latitude': 38.6270, 'longitude': -90.1994}
+
+        actual = geodb['St. Louis']
+        self.assertAlmostEqual(actual['latitude'], 38.6270, places=4)
+        self.assertAlmostEqual(actual['longitude'], -90.1994, places=4)
+
         with self.assertRaises(KeyError):
             geodb['Bahia']
 


### PR DESCRIPTION
Re: Issue https://github.com/honzajavorek/redis-collections/issues/104, this PR adds `GeoDB`, a new interface for the Redis GEO commands. See the [tests](https://github.com/honzajavorek/redis-collections/compare/geodb?expand=1#diff-12ae233241f404ad5e7ceaf1b6bbd53cR251) for example uses.

Also:
* This library now requires `redis-py` 3.1.0
* The version will be 0.6.0 after this merge