### PR TITLE
Release 0.6.0

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,7 +7,8 @@ Releases
 --------
 
 - 0.6.0:
-    - **Breaking change**: This library now requires `redis-py` 3.1.0+.
+    - **Breaking change**: This library now requires a Redis server at version 2.8.0 or above.
+    - **Breaking change**: This library now depends `redis-py` version 3.1.0 or above.
     - **New collection**: Added the ``GeoDB`` collection, a high-level interface for Redis's GEO commands.
 - 0.5.2:
     - **Documentation updates**: This was a documentation-only release with no code changes from 0.5.0

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,6 +3,42 @@
 Changelog
 =========
 
+Releases
+--------
+
+- 0.6.0:
+    - **Breaking change**: This library now requires `redis-py` 3.1.0+.
+    - **New collection**: Added the ``GeoDB`` collection, a high-level interface for Redis's GEO commands.
+- 0.5.2:
+    - **Documentation updates**: This was a documentation-only release with no code changes from 0.5.0
+- 0.5.1:
+    - **Requirements updates**: This release added the `six` library to the ``setup.py`` requirements; it had been missing before.
+- 0.5.0:
+    - **Breaking change**: This library now requires `redis-py` 3.0.0+.
+    - **Breaking change**: Data is now pickled using the highest protocol version supported by Python.
+      You can specify the ``pickle_protocol`` with a keyword argument - see :ref:`usage-notes`.
+      To connect to a collection created with an older version of this package, set ``pickle_protocol=None``. See also `PR #101 <https://github.com/honzajavorek/redis-collections/pull/101>`_.
+    - **Python support**: Python 3.3 is no longer supported.
+- 0.4.2:
+    - **Domain sockets support**: This is a bugfix release that enables connecting to a Redis server over a Unix domain socket.
+- 0.4.1:
+    - **SCAN methods**: Redis-specific ``scan_`` methods on ``Dict`` (and its subclassess), ``Set``,
+      and ``SortedSetCounter``. See `PR #97 <https://github.com/honzajavorek/redis-collections/pull/97>`_ for
+      details.
+    - **Initialization changes**: Collections no longer query Redis at instantiation - thanks to ArminGruner.
+- 0.4.0:
+    - **Syncable collections**: ``SyncableDict``, ``SyncableList``, ``SyncableSet``, and others are
+      collections that hold items locally (which speeds up operations),
+      but can sync them with Redis (which provides persistence).
+    - **Offload to Redis**: `LRUDict`` is a dict-like collection that holds a limited number of items
+      locally, pushing least-recently used items to a Redis Hash.
+    - **Sorted Set collection**: ``SortedSetCounter`` is a Pythonic interface to the Redis Sorted Set
+      structure. It behaves a bit like a Counter, but its values are restricted to
+      floating point numbers.
+    - **Version compatibility**: ``Set.random_sample`` now works for Redis servers under version 2.6.0
+
+See the `GitHub Releases page <https://github.com/honzajavorek/redis-collections/releases>`_ for information on earlier releases.
+
 Versioning
 ----------
 
@@ -19,138 +55,3 @@ After 1.0 is released:
 - Releases with breaking changes will be tagged as 2.0.0, 3.0.0, etc.
 - Releases with new features will be tagged as 1.1.0, 1.2.0, etc.
 - Bug fix releases will be tagged as 1.0.1, 1.0.2, etc.
-
-Breaking changes
-----------------
-
-0.6.x
-^^^^^
-
-- The 3.1.x release of `redis-py` is now required. This isn't explicitly
-  backward-incompatible, but be aware.
-
-0.5.x
-^^^^^
-
-- The 3.0.x release of `redis-py` is now required. Since it's not
-  backward-compatible with older versions, this library had to change as well.
-
-- Data is now pickled using the highest protocol version supported by Python.
-
-  You can specify the ``pickle_protocol`` with a keyword argument - see
-  :ref:`usage-notes`.
-
-  To connect to a collection created with an older version of this package,
-  set ``pickle_protocol=None``.
-
-  See also `PR #101 <https://github.com/honzajavorek/redis-collections/pull/101>`_.
-
-- Python 3.3 is no longer supported.
-
-0.4.x
-^^^^^
-
-Nothing should have broken from 0.3.x to 0.4.x.
-
-0.3.x
-^^^^^
-
-0.3.0 introduced some breaking changes:
-
-- ``List`` slicing, ``Set`` methods like ``union``, and ``Counter`` operator
-  methods now return Python objects instead of creating new Redis collections
-  at randomly-generated keys.
-
-  For example, previously ``List([0, 1, 2])[:1]`` would create a new ``List``
-  and store its items in Redis - now it returns a Python ``list``.
-
-  Methods like ``copy`` (all collections) and ``fromkeys`` (``Dict``) that
-  allow you to specify a Redis key as a keyword argument will still create new
-  Redis Collections.
-
-- The non-standard ``List.get`` method was removed, as the standard
-  ``List.__getitem__`` method is no longer particularly inefficient.
-
-- ``Dict`` and ``Set`` now treat numeric types (``int``, ``float``,
-  ``complex``, ``Fraction``, ``Decimal``) differently.
-  Previously it was possible to store, e.g., both ``1.0`` and ``1`` as ``Set``
-  elements or ``Dict`` keys, which is not possible with the Python equivalents.
-
-  Similarly, when using Python 2, ``Dict`` and ``Set`` now treat ``unicode``
-  and ``str`` types differently.
-  It's no longer possible to store, e.g. both ``u'a'`` and ``b'a'`` in the same
-  collection, and the behavior now matches the Python 2 equivalents.
-
-  See `PR #60
-  <https://github.com/honzajavorek/redis-collections/pull/61#issue-171307493>`_
-  for details.
-
-New features
-------------
-
-0.6.x
-^^^^^
-
-0.6.0 includes:
-
-- Added the ``GeoDB`` collection, a high-level interface for Redis's GEO commands.
-
-0.4.x
-^^^^^
-
-0.4.2 includes:
-
-- Fixed support for using a Redis server listening on a Unix domain socket
-  instead of a network socket.
-
-0.4.1 includes:
-
-- Redis-specific ``scan_`` methods on ``Dict`` (and its subclassess), ``Set``,
-  and ``SortedSetCounter``. See
-  `PR #97 <https://github.com/honzajavorek/redis-collections/pull/97>`_ for
-  details.
-
-- Collections no longer query Redis at instantiation - thanks @ArminGruner.
-
-
-0.4.0 introduced several new collections:
-
-- ``LRUDict`` is a dict-like collection that holds a limited number of items
-  locally, pushing least-recently used items to a Redis Hash.
-
-- ``SyncableDict``, ``SyncableList``, ``SyncableSet``, and others are
-  collections that hold items locally (which speeds up operations),
-  but can sync them with Redis (which provides persistence).
-
-- ``SortedSetCounter`` is a Pythonic interface to the Redis Sorted Set
-  structure.
-  It behaves a bit like a Counter, but its values are restricted to
-  floating point numbers.
-
-See the API Documentation for more details.
-
-Also:
-
-- The non-standard ``Set.random_sample`` method now works for Redis servers
-  running Redis < 2.6.0.
-  See `PR #80 <https://github.com/honzajavorek/redis-collections/pull/80>`_ for
-  details.
-
-
-0.3.x
-^^^^^
-
-- `Slicing and indexing for List
-  <https://github.com/honzajavorek/redis-collections/issues/55>`_ should now be
-  complete - no methods raise ``NotImplementedError``.
-
-- `Cross-process Dict access
-  <https://github.com/honzajavorek/redis-collections/issues/58>`_ should now
-  work for Python 3.3 and later again.
-
-- `Deque <https://github.com/honzajavorek/redis-collections/issues/6>`_ was
-  added.
-
-See the `0.3.0 milestone in GitHub
-<https://github.com/honzajavorek/redis-collections/milestone/1>`_ for more
-details.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -30,7 +30,7 @@ Releases
     - **Syncable collections**: ``SyncableDict``, ``SyncableList``, ``SyncableSet``, and others are
       collections that hold items locally (which speeds up operations),
       but can sync them with Redis (which provides persistence).
-    - **Offload to Redis**: `LRUDict`` is a dict-like collection that holds a limited number of items
+    - **Offload to Redis**: ``LRUDict`` is a dict-like collection that holds a limited number of items
       locally, pushing least-recently used items to a Redis Hash.
     - **Sorted Set collection**: ``SortedSetCounter`` is a Pythonic interface to the Redis Sorted Set
       structure. It behaves a bit like a Counter, but its values are restricted to

--- a/redis_collections/__init__.py
+++ b/redis_collections/__init__.py
@@ -8,12 +8,12 @@ __license__ = 'ISC'
 __copyright__ = 'Copyright 2013-? Honza Javorek'
 
 
-from .base import RedisCollection  # NOQA
-from .dicts import DefaultDict, Dict, Counter  # NOQA
-from .lists import Deque, List  # NOQA
-from .sets import Set  # NOQA
-from .sortedsets import GeoDB, SortedSetCounter  # NOQA
-from .syncable import (  # NOQA
+from .base import RedisCollection
+from .dicts import DefaultDict, Dict, Counter
+from .lists import Deque, List
+from .sets import Set
+from .sortedsets import GeoDB, SortedSetCounter
+from .syncable import (
     LRUDict,
     SyncableDict,
     SyncableCounter,

--- a/redis_collections/sets.py
+++ b/redis_collections/sets.py
@@ -18,7 +18,6 @@ except ImportError:
 
 from functools import reduce
 import operator
-import random
 
 import six
 
@@ -162,10 +161,6 @@ class Set(RedisCollection, collections_abc.MutableSet):
         :param k: Size of the sample, defaults to 1.
         :rtype: :class:`list`
 
-        .. note::
-            This method is not available on the Python :class:`set`.
-            When Redis version < 2.6 is being used the whole set is stored
-            in memory and the sample is computed in Python.
         """
         # k == 0: no work to do
         if k == 0:
@@ -174,16 +169,8 @@ class Set(RedisCollection, collections_abc.MutableSet):
         elif k == 1:
             results = [self.redis.srandmember(self.key)]
         # k != 1, Redis version >= 2.6: compute in Redis
-        elif self.redis_version >= (2, 6, 0):
-            results = self.redis.srandmember(self.key, k)
-        # positive k, Redis version < 2.6: sample without replacement
-        elif k > 1:
-            seq = list(self.__iter__())
-            return random.sample(seq, min(k, len(seq)))
-        # negative k, Redis version < 2.6: sample with replacement
         else:
-            seq = list(self.__iter__())
-            return [random.choice(seq) for __ in six.moves.xrange(abs(k))]
+            results = self.redis.srandmember(self.key, k)
 
         return [self._unpickle(x) for x in results]
 

--- a/redis_collections/sortedsets.py
+++ b/redis_collections/sortedsets.py
@@ -389,6 +389,10 @@ class GeoDB(SortedSetBase):
 
     This allows for quick approximations of distances between places, and
     for quick searching within a given radius.
+
+    .. note::
+        This class requires Redis server version 3.2.0 or greater.
+
     """
 
     def __init__(self, *args, **kwargs):

--- a/tests/test_sets.py
+++ b/tests/test_sets.py
@@ -383,21 +383,16 @@ class SetTest(RedisTestCase):
         self.assertEqual(s.random_sample(), ['a'])
 
         s = self.create_set('ab')
-        for redis_version in [(2, 6, 0), (2, 4, 0)]:
-            # Test both the Redis implementation and Python implementation
-            if s.redis_version >= (2, 6, 0):
-                s._redis_version = redis_version
+        self.assertEqual(sorted(s.random_sample(2)), ['a', 'b'])
+        self.assertEqual(sorted(s.random_sample(3)), ['a', 'b'])
 
-            self.assertEqual(sorted(s.random_sample(2)), ['a', 'b'])
-            self.assertEqual(sorted(s.random_sample(3)), ['a', 'b'])
-
-            # Negative k samples with replacement. With two items this should
-            # eventually break.
-            while True:
-                actual = sorted(s.random_sample(-2))
-                expected = ['a', 'b']
-                if actual == expected:
-                    break
+        # Negative k samples with replacement. With two items this should
+        # eventually break.
+        while True:
+            actual = sorted(s.random_sample(-2))
+            expected = ['a', 'b']
+            if actual == expected:
+                break
 
     def test_add_unicode(self):
         for init in (self.create_set, set):


### PR DESCRIPTION
This PR gathers together changes for the 0.6.0 release.

Of note:
* We now require `redis-py` 3.1.0+
* We now require Redis server 2.8.0+
* The `GeoDB` collection is now available