### PR TITLE
Drop Python 2.7 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 # Packages
 *.egg
+*.eggs
 *.egg-info
 dist
 build

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: "python"
 dist: xenial
 
 python:
-    - "2.7"
     - "3.4"
     - "3.5"
     - "3.6"
@@ -22,7 +21,7 @@ deploy:
   password:
     secure: "NLHLE9kVASnibrSDckdt1lmf8CfnKevmpCgAkrg2R+ajxlz3iNRfdKhSxJhExC+VMYryLBGOoeOrV+HwkZv2Lo3LlCstmh7y8k/AKp1v02xZvaOtD4w37eI23JwpNA/yXm/IZqy96cxHd4PdX6pul7xKoFRUj6Mc0PVWe+/izWg="
   on:
-    python: "2.7"
+    python: "3.6"
     tags: true
     repo: "honzajavorek/redis-collections"
     distributions: "sdist bdist_wheel"

--- a/docs/usage-notes.rst
+++ b/docs/usage-notes.rst
@@ -157,10 +157,6 @@ This behavior applies to ``complex``, ``float``, ``Decimal``, and ``Fraction``
 values that have an integer equivalent. It doesn't apply to values that don't
 have an integer equivalent (such as ``1.1`` or ``complex(1, 1)``).
 
-On Python 2 only, ``unicode`` types are converted to ``str`` types
-(with UTF-8 encoding) before being sent to Redis. ``str`` types are decoded to
-``unicode`` types after being retrieved from Redis (if possible).
-
 Security considerations
 -----------------------
 

--- a/redis_collections/__init__.py
+++ b/redis_collections/__init__.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import division, print_function, unicode_literals
-
 __title__ = 'redis-collections'
 __version__ = '0.6.0'
 __author__ = 'Honza Javorek'

--- a/redis_collections/base.py
+++ b/redis_collections/base.py
@@ -14,11 +14,11 @@ import pickle
 import redis
 import six
 
-NUMERIC_TYPES = six.integer_types + (float, Decimal, Fraction, complex)
+NUMERIC_TYPES = (int,) + (float, Decimal, Fraction, complex)
 
 
 @six.add_metaclass(abc.ABCMeta)
-class RedisCollection(object):
+class RedisCollection:
     """Abstract class providing backend functionality for all the other
     Redis collections.
     """
@@ -99,7 +99,7 @@ class RedisCollection(object):
         # byte strings. This method encodes unicode types to str to help match
         # Python's behavior.
         # The length of {b'a', u'a'} is 1 on Python 2.x and 2 on Python 3.x
-        if isinstance(data, six.text_type):
+        if isinstance(data, str):
             data = data.encode('utf-8')
 
         return self._pickle_3(data)
@@ -133,7 +133,7 @@ class RedisCollection(object):
         # Because we encoded text data in the pickle method, we should decode
         # it on the way back out
         data = pickle.loads(string) if string else None
-        if isinstance(data, six.binary_type):
+        if isinstance(data, bytes):
             try:
                 data = data.decode('utf-8')
             except UnicodeDecodeError:
@@ -262,4 +262,4 @@ class RedisCollection(object):
     def __repr__(self):
         cls_name = self.__class__.__name__
         data = self._repr_data()
-        return '<redis_collections.%s at %s %s>' % (cls_name, self.key, data)
+        return '<redis_collections.{} at {} {}>'.format(cls_name, self.key, data)

--- a/redis_collections/base.py
+++ b/redis_collections/base.py
@@ -1,10 +1,7 @@
-# -*- coding: utf-8 -*-
 """
 base
 ~~~~
 """
-from __future__ import division, print_function, unicode_literals
-
 import abc
 from decimal import Decimal
 from fractions import Fraction

--- a/redis_collections/base.py
+++ b/redis_collections/base.py
@@ -5,11 +5,8 @@ base
 import abc
 from decimal import Decimal
 from fractions import Fraction
-import uuid
-
-# We use pickle instead of cPickle on Python 2 intentionally, see
-# http://bugs.python.org/issue5518
 import pickle
+import uuid
 
 import redis
 

--- a/redis_collections/dicts.py
+++ b/redis_collections/dicts.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 r"""
 dicts
 ~~~~~
@@ -20,8 +19,6 @@ Each collection stores its items in a Redis
     See :ref:`Hashing` for more information.
 
 """
-from __future__ import division, print_function, unicode_literals
-
 try:
     import collections.abc as collections_abc
 except ImportError:

--- a/redis_collections/dicts.py
+++ b/redis_collections/dicts.py
@@ -23,8 +23,6 @@ import collections.abc as collections_abc
 import collections
 import operator
 
-import six
-
 from .base import RedisCollection
 
 
@@ -40,13 +38,8 @@ class Dict(RedisCollection, collections_abc.MutableMapping):
     from Python 2.7's dictionary type are not implemented.
     """
 
-    if six.PY2:
-        _pickle_key = RedisCollection._pickle_2
-        _unpickle_key = RedisCollection._unpickle_2
-    else:
-        _pickle_key = RedisCollection._pickle_3
-        _unpickle_key = RedisCollection._unpickle
-
+    _pickle_key = RedisCollection._pickle_3
+    _unpickle_key = RedisCollection._unpickle
     _pickle_value = RedisCollection._pickle_3
 
     class __missing_value:
@@ -146,7 +139,7 @@ class Dict(RedisCollection, collections_abc.MutableMapping):
         pickled_values = self.redis.hmget(self.key, *pickled_keys)
 
         ret = []
-        for k, v in six.moves.zip(keys, pickled_values):
+        for k, v in zip(keys, pickled_values):
             value = self.cache.get(k, self._unpickle(v))
             ret.append(value)
 

--- a/redis_collections/dicts.py
+++ b/redis_collections/dicts.py
@@ -34,8 +34,6 @@ class Dict(RedisCollection, collections_abc.MutableMapping):
     <https://docs.python.org/3/library/stdtypes.html#mapping-types-dict>`_ for
     usage notes.
 
-    The :func:`viewitems`, :func:`viewkeys`, and :func:`viewvalues` methods
-    from Python 2.7's dictionary type are not implemented.
     """
 
     _pickle_key = RedisCollection._pickle_3
@@ -430,8 +428,6 @@ class Counter(Dict):
     Counter inherits from Dict, so see its API documentation for information
     on other methods.
 
-    The :func:`viewitems`, :func:`viewkeys`, and :func:`viewvalues` methods
-    from Python 2.7's Counter type are not implemented.
     """
 
     def __init__(self, *args, **kwargs):
@@ -670,8 +666,6 @@ class DefaultDict(Dict):
     DefaultDict inherits from Dict, so see its API documentation for
     information on other methods.
 
-    The :func:`viewitems`, :func:`viewkeys`, and :func:`viewvalues` methods
-    from Python 2.7's Counter type are not implemented.
     """
 
     def __init__(self, *args, **kwargs):

--- a/redis_collections/dicts.py
+++ b/redis_collections/dicts.py
@@ -49,7 +49,7 @@ class Dict(RedisCollection, collections_abc.MutableMapping):
 
     _pickle_value = RedisCollection._pickle_3
 
-    class __missing_value(object):
+    class __missing_value:
         def __repr__(self):
             # Specified here so that the documentation shows a useful string
             # for methods that take __marker as a keyword argument
@@ -90,7 +90,7 @@ class Dict(RedisCollection, collections_abc.MutableMapping):
         """
         data = args[0] if args else kwargs.pop('data', None)
         writeback = kwargs.pop('writeback', False)
-        super(Dict, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
         self.writeback = writeback
         self.cache = {}
@@ -106,7 +106,7 @@ class Dict(RedisCollection, collections_abc.MutableMapping):
     def __iter__(self, pipe=None):
         """Return an iterator over the keys of the dictionary."""
         pipe = self.redis if pipe is None else pipe
-        for k, v in six.iteritems(self._data(pipe)):
+        for k, v in self._data(pipe).items():
             yield k
 
     def __contains__(self, key):
@@ -204,7 +204,7 @@ class Dict(RedisCollection, collections_abc.MutableMapping):
         (without checking the local cache).
         """
         pipe = self.redis if pipe is None else pipe
-        items = six.iteritems(pipe.hgetall(self.key))
+        items = pipe.hgetall(self.key).items()
 
         return {self._unpickle_key(k): self._unpickle(v) for k, v in items}
 
@@ -215,7 +215,7 @@ class Dict(RedisCollection, collections_abc.MutableMapping):
     def iteritems(self, pipe=None):
         """Return an iterator over the dictionary's ``(key, value)`` pairs."""
         pipe = self.redis if pipe is None else pipe
-        for k, v in six.iteritems(self._data(pipe)):
+        for k, v in self._data(pipe).items():
             yield k, self.cache.get(k, v)
 
     def keys(self):
@@ -473,7 +473,7 @@ class Counter(Dict):
                           method.
         :type writeback: bool
         """
-        super(Counter, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def __missing__(self, key):
         return 0
@@ -511,7 +511,7 @@ class Counter(Dict):
                 data.update(other)
 
             pickled_data = {}
-            for k, v in six.iteritems(data):
+            for k, v in data.items():
                 pickled_key = self._pickle_key(k)
                 pickled_value = self._pickle_value(op(self.get(k, 0), v))
                 pickled_data[pickled_key] = pickled_value
@@ -565,7 +565,7 @@ class Counter(Dict):
         missing values.
         """
         try:
-            super(Counter, self).__delitem__(key)
+            super().__delitem__(key)
         except KeyError:
             pass
 
@@ -601,7 +601,7 @@ class Counter(Dict):
 
             # Otherwise we need to update `self` in this transaction
             pickled_data = {}
-            for key, value in six.iteritems(result):
+            for key, value in result.items():
                 pickled_key = self._pickle_key(key)
                 pickled_value = self._pickle_value(value)
                 pickled_data[pickled_key] = pickled_value
@@ -714,7 +714,7 @@ class DefaultDict(Dict):
         else:
             default_factory = None
 
-        super(DefaultDict, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
         if default_factory is None:
             pass

--- a/redis_collections/dicts.py
+++ b/redis_collections/dicts.py
@@ -19,11 +19,7 @@ Each collection stores its items in a Redis
     See :ref:`Hashing` for more information.
 
 """
-try:
-    import collections.abc as collections_abc
-except ImportError:
-    import collections as collections_abc
-
+import collections.abc as collections_abc
 import collections
 import operator
 

--- a/redis_collections/lists.py
+++ b/redis_collections/lists.py
@@ -55,7 +55,7 @@ class List(RedisCollection, collections_abc.MutableSequence):
         """
         data = args[0] if args else kwargs.pop('data', None)
         writeback = kwargs.pop('writeback', False)
-        super(List, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
         self.__marker = uuid.uuid4().hex
         self.writeback = writeback
@@ -73,7 +73,7 @@ class List(RedisCollection, collections_abc.MutableSequence):
 
         if self.writeback:
             value = self.cache.get(0, value)
-            items = six.iteritems(self.cache)
+            items = self.cache.items()
             self.cache = {i - 1: v for i, v in items if i != 0}
 
         return value
@@ -94,7 +94,7 @@ class List(RedisCollection, collections_abc.MutableSequence):
                 raise IndexError
             pickled_value = pipe.rpop(self.key)
             value = self.cache.get(cache_index, self._unpickle(pickled_value))
-            items = six.iteritems(self.cache)
+            items = self.cache.items()
             self.cache = {i: v for i, v in items if i != cache_index}
 
             return value
@@ -118,7 +118,7 @@ class List(RedisCollection, collections_abc.MutableSequence):
             if self.writeback:
                 value = self.cache.get(cache_index, value)
                 new_cache = {}
-                for i, v in six.iteritems(self.cache):
+                for i, v in self.cache.items():
                     if i < cache_index:
                         new_cache[i] = v
                     elif i > cache_index:
@@ -416,7 +416,7 @@ class List(RedisCollection, collections_abc.MutableSequence):
         pipe = self.redis if pipe is None else pipe
         pipe.lpush(self.key, self._pickle(value))
         if self.writeback:
-            self.cache = {k + 1: v for k, v in six.iteritems(self.cache)}
+            self.cache = {k + 1: v for k, v in self.cache.items()}
             self.cache[0] = value
 
     def _insert_middle(self, index, value, pipe=None):
@@ -435,7 +435,7 @@ class List(RedisCollection, collections_abc.MutableSequence):
 
         if self.writeback:
             new_cache = {}
-            for i, v in six.iteritems(self.cache):
+            for i, v in self.cache.items():
                 if i < cache_index:
                     new_cache[i] = v
                 elif i >= cache_index:
@@ -583,7 +583,7 @@ class List(RedisCollection, collections_abc.MutableSequence):
             return self._transaction(eq_trans)
 
     def __mul__(self, times):
-        if not isinstance(times, six.integer_types):
+        if not isinstance(times, int):
             raise TypeError
 
         return self._python_cls(self.__iter__()) * times
@@ -592,7 +592,7 @@ class List(RedisCollection, collections_abc.MutableSequence):
         return self.__mul__(times)
 
     def __imul__(self, times):
-        if not isinstance(times, six.integer_types):
+        if not isinstance(times, int):
             raise TypeError
 
         # If multiplying by 1 there's no work to do
@@ -624,7 +624,7 @@ class List(RedisCollection, collections_abc.MutableSequence):
         return '[{}]'.format(', '.join(items))
 
     def _sync_helper(self, pipe):
-        for i, v in six.iteritems(self.cache):
+        for i, v in self.cache.items():
             pipe.lset(self.key, i, self._pickle(v))
 
         self.cache = {}
@@ -690,14 +690,14 @@ class Deque(List):
         if iterable is not None:
             kwargs['data'] = iterable
 
-        if (maxlen is not None) and not isinstance(maxlen, six.integer_types):
+        if (maxlen is not None) and not isinstance(maxlen, int):
             raise TypeError('an integer is required')
 
         if (maxlen is not None) and maxlen < 0:
             raise ValueError('maxlen must be non-negative')
 
         self.maxlen = maxlen
-        super(Deque, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
     # Magic methods
 
@@ -705,19 +705,19 @@ class Deque(List):
         if isinstance(index, slice):
             raise TypeError
 
-        return super(Deque, self).__delitem__(index)
+        return super().__delitem__(index)
 
     def __getitem__(self, index):
         if isinstance(index, slice):
             raise TypeError
 
-        return super(Deque, self).__getitem__(index)
+        return super().__getitem__(index)
 
     def __setitem__(self, index, value):
         if isinstance(index, slice):
             raise TypeError
 
-        return super(Deque, self).__setitem__(index, value)
+        return super().__setitem__(index, value)
 
     # Named methods
 
@@ -734,7 +734,7 @@ class Deque(List):
         # Pop from the left
         pipe.lpop(self.key)
         if self.writeback:
-            items = six.iteritems(self.cache)
+            items = self.cache.items()
             self.cache = {i - 1: v for i, v in items if i != 0}
 
     def append(self, value):
@@ -748,7 +748,7 @@ class Deque(List):
         # Append on the left
         len_self = pipe.lpush(self.key, self._pickle(value))
         if self.writeback:
-            self.cache = {k + 1: v for k, v in six.iteritems(self.cache)}
+            self.cache = {k + 1: v for k, v in self.cache.items()}
             self.cache[0] = value
 
         # Check the length restriction
@@ -759,7 +759,7 @@ class Deque(List):
         pipe.rpop(self.key)
         if self.writeback:
             cache_index = len_self - 1
-            items = six.iteritems(self.cache)
+            items = self.cache.items()
             self.cache = {i: v for i, v in items if i != cache_index}
 
     def appendleft(self, value):
@@ -912,7 +912,7 @@ class Deque(List):
         return self
 
     def __mul__(self, times):
-        if not isinstance(times, six.integer_types):
+        if not isinstance(times, int):
             raise TypeError
 
         return self._python_cls(self.__iter__(), self.maxlen) * times

--- a/redis_collections/lists.py
+++ b/redis_collections/lists.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 r"""
 lists
 ~~~~~
@@ -13,8 +12,6 @@ Each collection stores its values in a Redis
     in a collection, be sure to enable ``writeback``.
     See :ref:`Synchronization` for more information.
 """
-from __future__ import division, print_function, unicode_literals
-
 try:
     import collections.abc as collections_abc
 except ImportError:

--- a/redis_collections/lists.py
+++ b/redis_collections/lists.py
@@ -12,11 +12,7 @@ Each collection stores its values in a Redis
     in a collection, be sure to enable ``writeback``.
     See :ref:`Synchronization` for more information.
 """
-try:
-    import collections.abc as collections_abc
-except ImportError:
-    import collections as collections_abc
-
+import collections.abc as collections_abc
 import collections
 import itertools
 import uuid

--- a/redis_collections/lists.py
+++ b/redis_collections/lists.py
@@ -17,7 +17,6 @@ import collections
 import itertools
 import uuid
 
-import six
 from redis import ResponseError
 
 from .base import RedisCollection
@@ -147,7 +146,7 @@ class List(RedisCollection, collections_abc.MutableSequence):
             # Steps must be done index by index
             if index.step is not None:
                 pipe.multi()
-                for i in list(six.moves.xrange(len_self))[index]:
+                for i in list(range(len_self))[index]:
                     pipe.lset(self.key, i, self.__marker)
                 pipe.lrem(self.key, 0, self.__marker)
             # Slice covers entire range: delete the whole list
@@ -284,10 +283,10 @@ class List(RedisCollection, collections_abc.MutableSequence):
             # Loop through each index for slices with steps
             if index.step is not None:
                 new_values = list(value)
-                change_indexes = six.moves.xrange(start, stop, step)
+                change_indexes = range(start, stop, step)
                 if len(new_values) != len(change_indexes):
                     raise ValueError
-                for i, v in six.moves.zip(change_indexes, new_values):
+                for i, v in zip(change_indexes, new_values):
                     pipe.lset(self.key, i, self._pickle(v))
             # For slices without steps retrieve the items to the left and right
             # of the slice, clear the collection, then re-insert the items
@@ -490,7 +489,7 @@ class List(RedisCollection, collections_abc.MutableSequence):
                 self._sync_helper(pipe)
 
             n = self.__len__(pipe)
-            for i in six.moves.xrange(n // 2):
+            for i in range(n // 2):
                 left = pipe.lindex(self.key, i)
                 right = pipe.lindex(self.key, n - i - 1)
                 pipe.lset(self.key, i, right)
@@ -569,7 +568,7 @@ class List(RedisCollection, collections_abc.MutableSequence):
             if self_len != other_len:
                 return False
 
-            for v_self, v_other in six.moves.zip(self_values, other_values):
+            for v_self, v_other in zip(self_values, other_values):
                 if v_self != v_other:
                     return False
 
@@ -613,7 +612,7 @@ class List(RedisCollection, collections_abc.MutableSequence):
             pipe.multi()
 
             # Write the values repeatedly
-            for __ in six.moves.xrange(times - 1):
+            for __ in range(times - 1):
                 pipe.rpush(self.key, *pickled_values)
 
         self._transaction(imul_trans)
@@ -871,11 +870,11 @@ class Deque(List):
             # When n is positive we can use the built-in Redis command
             if forward:
                 pipe.multi()
-                for __ in six.moves.xrange(steps):
+                for __ in range(steps):
                     pipe.rpoplpush(self.key, self.key)
             # When n is negative we must use Python
             else:
-                for __ in six.moves.xrange(steps):
+                for __ in range(steps):
                     pickled_value = pipe.lpop(self.key)
                     pipe.rpush(self.key, pickled_value)
 

--- a/redis_collections/sets.py
+++ b/redis_collections/sets.py
@@ -49,7 +49,7 @@ class Set(RedisCollection, collections_abc.MutableSet):
         :type key: str
         """
         data = args[0] if args else kwargs.pop('data', None)
-        super(Set, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
         if data:
             self.update(data)

--- a/redis_collections/sets.py
+++ b/redis_collections/sets.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 sets
 ~~~~~
@@ -9,8 +8,6 @@ Its elements are stored in a Redis `set <http://redis.io/commands#set>`_
 structure.
 
 """
-from __future__ import division, print_function, unicode_literals
-
 try:
     import collections.abc as collections_abc
 except ImportError:

--- a/redis_collections/sets.py
+++ b/redis_collections/sets.py
@@ -12,8 +12,6 @@ import collections.abc as collections_abc
 from functools import reduce
 import operator
 
-import six
-
 from .base import RedisCollection
 
 
@@ -25,11 +23,7 @@ class Set(RedisCollection, collections_abc.MutableSet):
     <https://docs.python.org/3/library/stdtypes.html#set>`_ for usage notes.
     """
 
-    if six.PY2:
-        _pickle = RedisCollection._pickle_2
-        _unpickle = RedisCollection._unpickle_2
-    else:
-        _pickle = RedisCollection._pickle_3
+    _pickle = RedisCollection._pickle_3
 
     def __init__(self, *args, **kwargs):
         """

--- a/redis_collections/sets.py
+++ b/redis_collections/sets.py
@@ -8,11 +8,7 @@ Its elements are stored in a Redis `set <http://redis.io/commands#set>`_
 structure.
 
 """
-try:
-    import collections.abc as collections_abc
-except ImportError:
-    import collections as collections_abc
-
+import collections.abc as collections_abc
 from functools import reduce
 import operator
 

--- a/redis_collections/sortedsets.py
+++ b/redis_collections/sortedsets.py
@@ -170,7 +170,7 @@ class SortedSetCounter(SortedSetBase):
         """
         data = args[0] if args else kwargs.pop('data', None)
 
-        super(SortedSetCounter, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
         if data:
             self.update(data)
@@ -395,7 +395,7 @@ class GeoDB(SortedSetBase):
     def __init__(self, *args, **kwargs):
         data = args[0] if args else kwargs.pop('data', None)
 
-        super(GeoDB, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
         if data:
             self.update(data)

--- a/redis_collections/sortedsets.py
+++ b/redis_collections/sortedsets.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 sortedsets
 ~~~~~~~~~~
@@ -9,8 +8,6 @@ Redis `Sorted Set <https://redis.io/commands#sorted_set>`_ type.
 Included collections are :class:`SortedSetCounter` and :class:`GeoDB`.
 
 """
-from __future__ import division, print_function, unicode_literals
-
 from .base import RedisCollection
 
 

--- a/redis_collections/syncable.py
+++ b/redis_collections/syncable.py
@@ -26,11 +26,7 @@ be loaded.
     >>> E
     {'one': 1, 'two': 2}
 """
-try:
-    import collections.abc as collections_abc
-except ImportError:
-    import collections as collections_abc
-
+import collections.abc as collections_abc
 import collections
 
 from .dicts import Counter, DefaultDict, Dict

--- a/redis_collections/syncable.py
+++ b/redis_collections/syncable.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 syncable
 ~~~~~~~~
@@ -27,8 +26,6 @@ be loaded.
     >>> E
     {'one': 1, 'two': 2}
 """
-from __future__ import division, print_function, unicode_literals
-
 try:
     import collections.abc as collections_abc
 except ImportError:

--- a/redis_collections/syncable.py
+++ b/redis_collections/syncable.py
@@ -34,7 +34,7 @@ from .lists import Deque, List
 from .sets import Set
 
 
-class _SyncableBase(object):
+class _SyncableBase:
     @property
     def redis(self):
         return self.persistence.redis
@@ -62,7 +62,7 @@ class SyncableDict(_SyncableBase, dict):
     def __init__(self, **kwargs):
         self.persistence = Dict(**kwargs)
 
-        super(SyncableDict, self).__init__()
+        super().__init__()
         self.update(self.persistence)
 
     def sync(self):
@@ -83,7 +83,7 @@ class SyncableCounter(_SyncableBase, collections.Counter):
     def __init__(self, **kwargs):
         self.persistence = Counter(**kwargs)
 
-        super(SyncableCounter, self).__init__()
+        super().__init__()
         self.update(self.persistence)
 
     def sync(self):
@@ -104,7 +104,7 @@ class SyncableDefaultDict(_SyncableBase, collections.defaultdict):
     def __init__(self, *args, **kwargs):
         self.persistence = DefaultDict(*args, **kwargs)
 
-        super(SyncableDefaultDict, self).__init__(args[0] if args else None)
+        super().__init__(args[0] if args else None)
         self.update(self.persistence)
 
     def sync(self):
@@ -124,7 +124,7 @@ class SyncableList(_SyncableBase, list):
     def __init__(self, **kwargs):
         self.persistence = List(**kwargs)
 
-        super(SyncableList, self).__init__()
+        super().__init__()
         self.extend(self.persistence)
 
     def sync(self):
@@ -144,7 +144,7 @@ class SyncableDeque(_SyncableBase, collections.deque):
     def __init__(self, iterable=None, maxlen=None, **kwargs):
         self.persistence = Deque(iterable=iterable, maxlen=maxlen, **kwargs)
 
-        super(SyncableDeque, self).__init__(maxlen=self.persistence.maxlen)
+        super().__init__(maxlen=self.persistence.maxlen)
         self.extend(self.persistence)
 
     def sync(self):
@@ -164,7 +164,7 @@ class SyncableSet(_SyncableBase, set):
     def __init__(self, **kwargs):
         self.persistence = Set(**kwargs)
 
-        super(SyncableSet, self).__init__()
+        super().__init__()
         self.update(self.persistence)
 
     def sync(self):
@@ -205,7 +205,7 @@ class LRUDict(_SyncableBase, collections_abc.MutableMapping):
         self.cache = collections.OrderedDict()
         self.persistence = Dict(**kwargs)
 
-        super(LRUDict, self).__init__()
+        super().__init__()
         self.update(self.persistence)
 
     def __contains__(self, key):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
 redis
-six

--- a/setup.py
+++ b/setup.py
@@ -1,24 +1,10 @@
-# -*- coding: utf-8 -*-
-from __future__ import division, print_function, unicode_literals
-
 import io
 import os
 import re
 import subprocess
 import sys
 
-try:
-    from setuptools import setup, find_packages
-except ImportError:
-    from distutils.core import setup, find_packages  # NOQA
-
-# Hack to prevent stupid "TypeError: 'NoneType' object is not callable"
-# error in multiprocessing/util.py _exit_function when running `python
-# setup.py test`
-try:
-    import multiprocessing  # NOQA
-except ImportError:
-    pass
+from setuptools import setup, find_packages
 
 
 base_path = os.path.dirname(__file__)
@@ -49,7 +35,7 @@ setup(
     license='ISC',
     packages=find_packages(exclude=['tests']),
     include_package_data=True,
-    install_requires=['redis>=3.1.0,<4.0.0', 'six>=1.0.0,<2.0.0'],
+    install_requires=['redis>=3.1.0,<4.0.0'],
     zip_safe=False,
     keywords=['redis', 'persistence'],
     classifiers=(
@@ -57,7 +43,6 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: ISC License (ISCL)',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Topic :: Database',
     )

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ setup(
     license='ISC',
     packages=find_packages(exclude=['tests']),
     include_package_data=True,
+    python_requires='>=3.4',
     install_requires=['redis>=3.1.0,<4.0.0'],
     zip_safe=False,
     keywords=['redis', 'persistence'],

--- a/tests/base.py
+++ b/tests/base.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import division, print_function, unicode_literals
-
 import unittest
 
 import redis

--- a/tests/test_dicts.py
+++ b/tests/test_dicts.py
@@ -1,7 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-from __future__ import division, print_function, unicode_literals
-
 import collections
 import operator
 import unittest

--- a/tests/test_dicts.py
+++ b/tests/test_dicts.py
@@ -2,8 +2,6 @@ import collections
 import operator
 import unittest
 
-import six
-
 from redis_collections import Counter, DefaultDict, Dict, List
 
 from .base import RedisTestCase
@@ -37,9 +35,7 @@ class DictTest(RedisTestCase):
         d['e'] = 'f'
         d[1] = 'g'
         self.assertEqual(d.getmany('a', 'e', 1.0, 'x'), ['b', 'f', 'g', None])
-
-        if not six.PY2:
-            self.assertEqual(d.getmany(b'a', b'c'), [None, None])
+        self.assertEqual(d.getmany(b'a', b'c'), [None, None])
 
     def test_init(self):
         init_seq = [
@@ -101,12 +97,10 @@ class DictTest(RedisTestCase):
             with self.assertRaises(KeyError):
                 del D[2]
 
-        # b'a' and 'a' hash to the same thing and are equal in Python 2
         # b'a' and 'a' hash to the same thing but aren't equal in Python 3
-        if not six.PY2:
-            del redis_dict[b'a']
-            del python_dict[b'a']
-            self.assertEqual(redis_dict, python_dict)
+        del redis_dict[b'a']
+        del python_dict[b'a']
+        self.assertEqual(redis_dict, python_dict)
 
     def test_in(self):
         redis_dict = self.create_dict()
@@ -119,11 +113,7 @@ class DictTest(RedisTestCase):
             self.assertIn(1.0, D)
             self.assertIn(1, D)
             self.assertNotIn('b', D)
-
-            if six.PY2:
-                self.assertIn(b'a', D)
-            else:
-                self.assertNotIn(b'a', D)
+            self.assertNotIn(b'a', D)
 
     def test_items(self):
         d = self.create_dict()
@@ -203,12 +193,11 @@ class DictTest(RedisTestCase):
             self.assertEqual(D.pop('a', b'default'), b'default')
             self.assertRaises(KeyError, D.pop, 'a')
 
-            if not six.PY2:
-                D['a'] = 1
-                D[b'a'] = 2
-                self.assertEqual(D.pop('a'), 1)
-                self.assertNotIn('a', D)
-                self.assertIn(b'a', D)
+            D['a'] = 1
+            D[b'a'] = 2
+            self.assertEqual(D.pop('a'), 1)
+            self.assertNotIn('a', D)
+            self.assertIn(b'a', D)
 
     def test_popitem(self):
         redis_dict = self.create_dict()
@@ -220,12 +209,11 @@ class DictTest(RedisTestCase):
             self.assertNotIn('a', D)
             self.assertRaises(KeyError, D.popitem)
 
-            if not six.PY2:
-                D['a'] = 1
-                D[b'a'] = 2
-                self.assertEqual(D.popitem(), ('a', 1))
-                self.assertNotIn('a', D)
-                self.assertIn(b'a', D)
+            D['a'] = 1
+            D[b'a'] = 2
+            self.assertEqual(D.popitem(), ('a', 1))
+            self.assertNotIn('a', D)
+            self.assertIn(b'a', D)
 
     def test_setdefault(self):
         d = self.create_dict()
@@ -407,7 +395,7 @@ class DictTest(RedisTestCase):
         redis_dict = self.create_dict()
 
         expected_dict = {}
-        for i in six.moves.range(1000):
+        for i in range(1000):
             expected_dict[i] = i * 100.0
             redis_dict[i] = i * 100.0
 
@@ -659,14 +647,12 @@ class CounterTest(RedisTestCase):
         python_counter &= collections.Counter('cdddd')
         self.assertEqual(redis_counter, python_counter)
 
-    @unittest.skipIf(six.PY2, 'Test applies to Python 3+ only')
     def test_pos(self):
         redis_counter = self.create_counter({'a': 1, 'b': -2, 'c': 3})
         python_counter = collections.Counter({'a': 1, 'b': -2, 'c': 3})
 
         self.assertEqual(+redis_counter, +python_counter)
 
-    @unittest.skipIf(six.PY2, 'Test applies to Python 3+ only')
     def test_neg(self):
         redis_counter = self.create_counter({'a': 1, 'b': -2, 'c': 3})
         python_counter = collections.Counter({'a': 1, 'b': -2, 'c': 3})

--- a/tests/test_dicts.py
+++ b/tests/test_dicts.py
@@ -22,7 +22,7 @@ class DictTest(RedisTestCase):
         for k, v in [
             ('a', 1),
             (b'a', 2),
-            (u'a', 3),
+            ('a', 3),
             (1, 'one'),
             (1.0, 'one point zero'),
         ]:
@@ -45,26 +45,26 @@ class DictTest(RedisTestCase):
         init_seq = [
             ('a', 1),
             (b'a', 2),
-            (u'a', 3),
+            ('a', 3),
             (1, 'one'),
             (1.0, 'one point zero'),
         ]
         redis_dict = self.create_dict(init_seq)
         python_dict = dict(init_seq)
-        six.assertCountEqual(self, redis_dict.items(), python_dict.items())
+        self.assertCountEqual(redis_dict.items(), python_dict.items())
 
         init_dict = dict(
             [
                 ('a', 1),
                 (b'a', 2),
-                (u'a', 3),
+                ('a', 3),
                 (1, 'one'),
                 (1.0, 'one point zero'),
             ]
         )
         redis_dict = self.create_dict(init_dict)
         python_dict = dict(init_dict)
-        six.assertCountEqual(self, redis_dict.items(), python_dict.items())
+        self.assertCountEqual(redis_dict.items(), python_dict.items())
 
     def test_key(self):
         d1 = self.create_dict()
@@ -80,7 +80,7 @@ class DictTest(RedisTestCase):
         for k, v in [
             ('a', 1),
             (b'a', 2),
-            (u'a', 3),
+            ('a', 3),
             (1, 'one'),
             (1.0, 'one point zero'),
         ]:

--- a/tests/test_lists.py
+++ b/tests/test_lists.py
@@ -228,7 +228,6 @@ class ListTest(RedisTestCase):
         redis_list = self.create_list(data)
         redis_cached = self.create_list(data, writeback=True)
 
-        # Python 2.x lists don't have a clear method
         for L in (redis_list, redis_cached):
             L[0] = 'Zero'
             L.clear()

--- a/tests/test_lists.py
+++ b/tests/test_lists.py
@@ -1,7 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-from __future__ import division, print_function, unicode_literals
-
 import collections
 import sys
 import unittest

--- a/tests/test_sets.py
+++ b/tests/test_sets.py
@@ -3,8 +3,6 @@ from fractions import Fraction
 import unittest
 import sys
 
-import six
-
 from redis_collections import List, Set
 
 from .base import RedisTestCase
@@ -456,7 +454,7 @@ class SetTest(RedisTestCase):
         redis_set = self.create_set()
 
         expected_elements = set()
-        for i in six.moves.range(1000):
+        for i in range(1000):
             elem = str(i)
             expected_elements.add(elem)
             redis_set.add(elem)

--- a/tests/test_sets.py
+++ b/tests/test_sets.py
@@ -1,7 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-from __future__ import division, print_function, unicode_literals
-
 from decimal import Decimal
 from fractions import Fraction
 import unittest

--- a/tests/test_sets.py
+++ b/tests/test_sets.py
@@ -411,7 +411,7 @@ class SetTest(RedisTestCase):
             complex(1.0, 0.0),
             Decimal(1.0),
             Fraction(2, 2),
-            u'a',
+            'a',
             b'a',
             'a',
         ]:

--- a/tests/test_sortedsets.py
+++ b/tests/test_sortedsets.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, unicode_literals
-
 from redis_collections import GeoDB, SortedSetCounter
 
 import six

--- a/tests/test_sortedsets.py
+++ b/tests/test_sortedsets.py
@@ -1,7 +1,5 @@
 from redis_collections import GeoDB, SortedSetCounter
 
-import six
-
 from .base import RedisTestCase
 
 
@@ -220,7 +218,7 @@ class SortedSetCounterTestCase(RedisTestCase):
         ssc = self.create_sortedset()
 
         expected_dict = {}
-        for i in six.moves.range(1000):
+        for i in range(1000):
             expected_dict[i] = i * 100.0
             ssc.set_score(i, i * 100.0)
 

--- a/tests/test_syncable.py
+++ b/tests/test_syncable.py
@@ -1,7 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-from __future__ import division, print_function, unicode_literals
-
 import collections
 import unittest
 


### PR DESCRIPTION
This PR removes the reliance on `six` and the Python 2 compatibility code. The next release will support Python 3.4+.