### PR TITLE
0.8.0 release

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,8 @@ Changelog
 Releases
 --------
 
+- 0.7.0:
+    - **Breaking change**: This library now supports Python versions 3.4 and later. The last version with Python 2.7 support is 0.6.0.
 - 0.6.0:
     - **Breaking change**: This library now requires a Redis server at version 2.8.0 or above.
     - **Breaking change**: This library now depends `redis-py` version 3.1.0 or above.
@@ -48,8 +50,8 @@ Versioning
 A 1.0 release is planned. Before that happens:
 
 - Releases with significant new features or breaking changes will be tagged as
-  0.7.x, 0.8.x, etc.
-- Bug fix releases will be tagged as 0.6.x
+  0.8.x, 0.9.x, etc.
+- Bug fix releases will be tagged as 0.7.x
 
 After 1.0 is released:
 

--- a/redis_collections/__init__.py
+++ b/redis_collections/__init__.py
@@ -1,5 +1,5 @@
 __title__ = 'redis-collections'
-__version__ = '0.6.0'
+__version__ = '0.7.0'
 __author__ = 'Honza Javorek'
 __license__ = 'ISC'
 __copyright__ = 'Copyright 2013-? Honza Javorek'


### PR DESCRIPTION
This PR bumps the version number and adds a note about Python 3.4+ compatibility.