### PR TITLE
 Avoid DeprecationWarning for redis-py 3.5.x 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ script:
     - "pip install --upgrade coveralls flake8"
     - "flake8 ."
     - "coverage run -m unittest discover"
-    - "pip install redis==3.4.2
+    - "pip install redis==3.4.2"
     - "coverage run -m unittest discover"
 
 services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ script:
     - "pip install --upgrade coveralls flake8"
     - "flake8 ."
     - "coverage run -m unittest discover"
-    - "pip install redis==3.4.2"
+    - "pip install redis==3.4.1"
     - "coverage run -m unittest discover"
 
 services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ script:
     - "pip install --upgrade coveralls flake8"
     - "flake8 ."
     - "coverage run -m unittest discover"
+    - "pip install redis==3.4.2
+    - "coverage run -m unittest discover"
 
 services:
     - "redis-server"

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,8 +6,10 @@ Changelog
 Releases
 --------
 
+- 0.8.1:
+    - **Version compatibility**: This library now supports `redis-py` version 3.5.x. The minimum support version remains 3.0.0.
 - 0.8.0:
-    - **Version compatibility**: This library now supports `redis-py` versions 3.4.0 and above.
+    - **Version compatibility**: This library now supports `redis-py` version 3.4.x. The minimum support version remains 3.0.0.
 - 0.7.1:
     - **Version compatibility**: This is a bugfix release to pin the `redis-py` dependency to below 3.4.0. A future version will add support for `redis-py` 3.4.0 and above.
 - 0.7.0:

--- a/redis_collections/__init__.py
+++ b/redis_collections/__init__.py
@@ -1,5 +1,5 @@
 __title__ = 'redis-collections'
-__version__ = '0.8.0'
+__version__ = '0.8.1'
 __author__ = 'Honza Javorek'
 __license__ = 'ISC'
 __copyright__ = 'Copyright 2013-? Honza Javorek'

--- a/redis_collections/base.py
+++ b/redis_collections/base.py
@@ -149,6 +149,13 @@ class RedisCollection(metaclass=abc.ABCMeta):
             self_kwargs.get('db', 0) == other_kwargs.get('db', 0)
         )
 
+    def _hmset(self, mapping, pipe=None):
+        pipe = self.redis if pipe is None else pipe
+        try:
+            return pipe.hset(self.key, mapping=mapping)
+        except TypeError:
+            return pipe.hmset(self.key, mapping)
+
     def _normalize_index(self, index, pipe=None):
         """Convert negative indexes into their positive equivalents."""
         pipe = self.redis if pipe is None else pipe

--- a/redis_collections/dicts.py
+++ b/redis_collections/dicts.py
@@ -339,7 +339,7 @@ class Dict(RedisCollection, collections_abc.MutableMapping):
                 pickled_data[self._pickle_key(k)] = self._pickle_value(v)
 
             if pickled_data:
-                pipe.hmset(self.key, pickled_data)
+                self._hmset(pickled_data, pipe=pipe)
 
         if use_redis:
             self._transaction(_update_helper_trans, other.key)
@@ -514,7 +514,7 @@ class Counter(Dict):
                 pickled_data[pickled_key] = pickled_value
 
             if pickled_data:
-                pipe.hmset(self.key, pickled_data)
+                self._hmset(pickled_data, pipe=pipe)
 
             if self.writeback:
                 self.cache.update(data)
@@ -607,7 +607,7 @@ class Counter(Dict):
 
             pipe.delete(self.key)
             if pickled_data:
-                pipe.hmset(self.key, pickled_data)
+                self._hmset(pickled_data, pipe=pipe)
 
         if other is None:
             result = self._transaction(op_trans)


### PR DESCRIPTION
This PR adds a wrapper around the `hmset` method, which has been [deprecated](https://github.com/andymccurdy/redis-py/blob/32a58406b2769f423170142e21d164c863697ebc/CHANGES#L24-L25) in `redis-py` version 3.5.0.

This library will continue to support `redis-py` 3.0.0 and above; this update is to avoid triggering the `DeprecationWarning` associated with the `hmset` change.