### PR TITLE
Python 3.9-style support for | and |= for Dict

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
     - "3.6"
     - "3.7"
     - "3.8"
+    - "3.9-dev"
 
 script:
     - "pip install --upgrade coveralls flake8"

--- a/redis_collections/dicts.py
+++ b/redis_collections/dicts.py
@@ -381,19 +381,18 @@ class Dict(RedisCollection, collections_abc.MutableMapping):
     def _merge_helper(self, other, swap=False):
         def _or_trans(pipe):
             pipe.multi()
-            left, right = (other, self) if swap else (self, other)
             new = {k: v for k, v in left.iteritems(pipe=pipe)}
             new.update({k: v for k, v in right.iteritems(pipe=pipe)})
             return new
 
+        left, right = (other, self) if swap else (self, other)
         if self._same_redis(other, self.__class__):
-            ret = self._transaction(_or_trans, other.key)
+            new = self._transaction(_or_trans, other.key)
         else:
-            ret = dict(self.iteritems())
-            ret.update(other)
-            return ret
+            new = {k: v for k, v in left.items()}
+            new.update({k: v for k, v in right.items()})
 
-        return ret
+        return new
 
     def __or__(self, other):
         """Merge the *other* dictionary into the current one, overwriting

--- a/tests/test_dicts.py
+++ b/tests/test_dicts.py
@@ -187,7 +187,6 @@ class DictTest(RedisTestCase):
         redis_dict = self.create_dict()
         python_dict = {}
         for D in (redis_dict, python_dict):
-            D = self.create_dict()
             D['a'] = 1
             self.assertEqual(D.pop('a'), 1)
             self.assertNotIn('a', D)
@@ -204,17 +203,10 @@ class DictTest(RedisTestCase):
         redis_dict = self.create_dict()
         python_dict = {}
         for D in (redis_dict, python_dict):
-            D = self.create_dict()
             D['a'] = 1
             self.assertEqual(D.popitem(), ('a', 1))
             self.assertNotIn('a', D)
             self.assertRaises(KeyError, D.popitem)
-
-            D['a'] = 1
-            D[b'a'] = 2
-            self.assertEqual(D.popitem(), ('a', 1))
-            self.assertNotIn('a', D)
-            self.assertIn(b'a', D)
 
     def test_setdefault(self):
         d = self.create_dict()

--- a/tests/test_dicts.py
+++ b/tests/test_dicts.py
@@ -418,7 +418,7 @@ class DictTest(RedisTestCase):
             (python_orig, python_new),
             (redis_orig, redis_new),
             (redis_orig, python_new),
-            (python_new, redis_orig),
+            (python_orig, redis_new),
         ]:
             self.assertEqual(orig | new, {'a': 0, 'b': 1, 'c': 1})
 

--- a/tests/test_dicts.py
+++ b/tests/test_dicts.py
@@ -1,5 +1,6 @@
 import collections
 import operator
+import sys
 import unittest
 
 from redis_collections import Counter, DefaultDict, Dict, List
@@ -567,7 +568,7 @@ class CounterTest(RedisTestCase):
         # Fail for non-counter types
         for c in (redis_counter, python_counter):
             with self.assertRaises(TypeError):
-                op(c, {'a': 2, 'b': 2, 'c': 2})
+                op(c, ('a', 2, 'b', 2, 'c', 2))
 
     def test_add(self):
         self._test_op(operator.add)


### PR DESCRIPTION
Re: #129, this PR adds `|` and `|=` operator support for `Dict` instances, a la Python 3.9.