### PR TITLE
0.1.3, the final release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,8 @@ sdist
 develop-eggs
 .installed.cfg
 
+.DS_Store
+
 # Installer logs
 pip-log.txt
 

--- a/README.rst
+++ b/README.rst
@@ -5,10 +5,12 @@ Redis Collections
 `redis-collections` is a Python library that provides a high-level
 interface to `Redis <http://redis.io/>`_, the excellent key-value store.
 
+As of 2024, this project is retired. This repository will remain available as
+a public archive.
+
 Quickstart
 ----------
 
-Install the library with ``pip install redis-collections``.
 Import the collections from the top-level ``redis_collections`` package.
 
 Standard collections
@@ -113,16 +115,10 @@ Documentation
 For more information, see
 `redis-collections.readthedocs.io <https://redis-collections.readthedocs.io/>`_
 
-Maintainers
------------
-
-- Bo Bayles (`@bbayles <http://github.com/bbayles>`_)
-- Honza Javorek (`@honzajavorek <http://github.com/honzajavorek>`_)
-
 License: ISC
 ------------
 
-© 2016-? Bo Bayles <bbayles@gmail.com> and contributors
+© 2016-2024 Bo Bayles <bbayles@gmail.com> and contributors
 © 2013-2016 Honza Javorek <mail@honzajavorek.cz> and contributors
 
 This work is licensed under `ISC license <https://en.wikipedia.org/wiki/ISC_license>`_.

--- a/docs/basic-usage.rst
+++ b/docs/basic-usage.rst
@@ -1,18 +1,7 @@
 .. _basic-usage:
 
-Installation and examples
-=========================
-
-Installation
-------------
-
-To get started, install the library with
-`pip <https://pip.pypa.io/en/stable/>`_:
-
-.. code-block:: shell
-
-    pip install redis-collections
-
+Examples
+========
 
 Basic usage
 -----------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,12 @@ Changelog
 Releases
 --------
 
+- 0.13.0:
+    - **The end**: This library has been retired. Thanks for the interest.
+- 0.12.0:
+    - **Version compatibility**: This library now supports Python 3.8 and higher.
+    - **Breaking change**: This library now requires a Redis server at version 5.0.0 or above.
+    - **Version compatibility** - This library now supports `redis-py` versions up to 6.0.0.
 - 0.11.0:
     - **Version compatibility**: This library now supports Python 3.7 and higher.
     - **Version compatibility** - This library now supports `redis-py` version 4.x (thanks to lionelnicolas). The minimum supported version is now 3.5.x.
@@ -59,20 +65,3 @@ Releases
     - **Version compatibility**: ``Set.random_sample`` now works for Redis servers under version 2.6.0
 
 See the `GitHub Releases page <https://github.com/redis-collections/redis-collections/releases>`_ for information on earlier releases.
-
-Versioning
-----------
-
-`redis-collections` is currently at version |release|.
-
-A 1.0 release is planned. Before that happens:
-
-- Releases with significant new features or breaking changes will be tagged as
-  0.11.x, 0.12.x, etc.
-- Bug fix releases will be tagged as 0.10.x
-
-After 1.0 is released:
-
-- Releases with breaking changes will be tagged as 2.0.0, 3.0.0, etc.
-- Releases with new features will be tagged as 1.1.0, 1.2.0, etc.
-- Bug fix releases will be tagged as 1.0.1, 1.0.2, etc.

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -4,8 +4,7 @@ Development
 ===========
 
 See the `GitHub project page
-<https://github.com/redis-collections/redis-collections/>`_ for source code, to file
-an issue, or to make a code contribution.
+<https://github.com/redis-collections/redis-collections/>`_ for source code.
 
 Philosophy
 ----------
@@ -28,10 +27,3 @@ Philosophy
 
 *   Behavior of "nested" collections is **undefined**. It is not recommended
     to create such structures. Use a collection of keys instead.
-
-*   The library will take advantage of features in new versions of Redis,
-    but will provide backports for older versions of Redis.
-
-    The earliest supported version of Redis is the one that ships with the
-    oldest supported LTS release of Ubuntu Linux (see
-    `packages.ubuntu.com <http://packages.ubuntu.com/redis-server>`_).

--- a/redis_collections/__init__.py
+++ b/redis_collections/__init__.py
@@ -1,9 +1,9 @@
 __title__ = 'redis-collections'
-__version__ = '0.12.0'
+__version__ = '0.13.0'
 __author__ = 'Honza Javorek'
 __maintainer__ = 'Bo Bayles'
 __license__ = 'ISC'
-__copyright__ = 'Copyright 2013-? Honza Javorek'
+__copyright__ = 'Copyright 2013-2024 Honza Javorek and Bo Bayles'
 
 
 from .base import RedisCollection

--- a/redis_collections/base.py
+++ b/redis_collections/base.py
@@ -2,6 +2,7 @@
 base
 ~~~~
 """
+
 import abc
 from decimal import Decimal
 from fractions import Fraction

--- a/redis_collections/dicts.py
+++ b/redis_collections/dicts.py
@@ -19,6 +19,7 @@ Each collection stores its items in a Redis
     See :ref:`Hashing` for more information.
 
 """
+
 import collections.abc as collections_abc
 import collections
 import operator

--- a/redis_collections/lists.py
+++ b/redis_collections/lists.py
@@ -12,6 +12,7 @@ Each collection stores its values in a Redis
     in a collection, be sure to enable ``writeback``.
     See :ref:`Synchronization` for more information.
 """
+
 import collections.abc as collections_abc
 import collections
 import itertools

--- a/redis_collections/sets.py
+++ b/redis_collections/sets.py
@@ -8,6 +8,7 @@ Its elements are stored in a Redis `set <http://redis.io/commands#set>`_
 structure.
 
 """
+
 import collections.abc as collections_abc
 from functools import reduce
 import operator

--- a/redis_collections/sortedsets.py
+++ b/redis_collections/sortedsets.py
@@ -8,6 +8,7 @@ Redis `Sorted Set <https://redis.io/commands#sorted_set>`__ type.
 Included collections are :class:`SortedSetCounter` and :class:`GeoDB`.
 
 """
+
 from redis.client import Pipeline
 
 from .base import RedisCollection

--- a/redis_collections/syncable.py
+++ b/redis_collections/syncable.py
@@ -36,6 +36,7 @@ The underlying :class:`RedisCollection` instance can be accessed from the
     This might not be appropriate for very large collections.
 
 """
+
 import collections.abc as collections_abc
 import collections
 


### PR DESCRIPTION
This PR has some final updates for this project, which is retiring after 11 years.

Thanks for your interest! Please consider [Redict](https://redict.io/) for your remote dictionary needs.